### PR TITLE
Add defaultFromName config option and bump to v0.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xtr-dev/payload-mailing",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Template-based email system with scheduling and job processing for PayloadCMS",
   "type": "module",
   "main": "dist/index.js",

--- a/src/services/MailingService.ts
+++ b/src/services/MailingService.ts
@@ -48,6 +48,12 @@ export class MailingService implements IMailingService {
     }
   }
 
+  private getDefaultFrom(): string {
+    const fromEmail = this.config.defaultFrom
+    const fromName = this.config.defaultFromName
+    return fromName && fromEmail ? `"${fromName}" <${fromEmail}>` : fromEmail || ''
+  }
+
   private registerHandlebarsHelpers(): void {
     Handlebars.registerHelper('formatDate', (date: Date, format?: string) => {
       if (!date) return ''
@@ -128,7 +134,7 @@ export class MailingService implements IMailingService {
       to: Array.isArray(options.to) ? options.to : [options.to],
       cc: options.cc ? (Array.isArray(options.cc) ? options.cc : [options.cc]) : undefined,
       bcc: options.bcc ? (Array.isArray(options.bcc) ? options.bcc : [options.bcc]) : undefined,
-      from: options.from || this.config.defaultFrom,
+      from: options.from || this.getDefaultFrom(),
       replyTo: options.replyTo,
       subject: subject || options.subject,
       html,
@@ -245,7 +251,7 @@ export class MailingService implements IMailingService {
       }) as QueuedEmail
 
       let emailObject: EmailObject = {
-        from: email.from || this.config.defaultFrom,
+        from: email.from || this.getDefaultFrom(),
         to: email.to,
         cc: email.cc || undefined,
         bcc: email.bcc || undefined,
@@ -262,7 +268,7 @@ export class MailingService implements IMailingService {
       }
 
       const mailOptions = {
-        from: emailObject.from || this.config.defaultFrom,
+        from: emailObject.from,
         to: emailObject.to,
         cc: emailObject.cc || undefined,
         bcc: emailObject.bcc || undefined,

--- a/src/services/MailingService.ts
+++ b/src/services/MailingService.ts
@@ -51,7 +51,15 @@ export class MailingService implements IMailingService {
   private getDefaultFrom(): string {
     const fromEmail = this.config.defaultFrom
     const fromName = this.config.defaultFromName
-    return fromName && fromEmail ? `"${fromName}" <${fromEmail}>` : fromEmail || ''
+
+    // Check if fromName exists, is not empty after trimming, and fromEmail exists
+    if (fromName && fromName.trim() && fromEmail) {
+      // Escape quotes in the display name to prevent malformed headers
+      const escapedName = fromName.replace(/"/g, '\\"')
+      return `"${escapedName}" <${fromEmail}>`
+    }
+
+    return fromEmail || ''
   }
 
   private registerHandlebarsHelpers(): void {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,6 +22,7 @@ export interface MailingPluginConfig {
     emails?: string | Partial<CollectionConfig>
   }
   defaultFrom?: string
+  defaultFromName?: string
   transport?: Transporter | MailingTransportConfig
   queue?: string
   retryAttempts?: number


### PR DESCRIPTION
- Add defaultFromName to MailingPluginConfig interface
- Update MailingService to format from field with name when available
- Add getDefaultFrom() helper method for consistent formatting
- Format as "Name" <email@domain.com> when both name and email are provided
- Bump version to 0.0.7

🤖 Generated with [Claude Code](https://claude.ai/code)