### PR TITLE
Fix TypeScript compatibility with PayloadCMS generated types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xtr-dev/payload-mailing",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Template-based email system with scheduling and job processing for PayloadCMS",
   "type": "module",
   "main": "dist/index.js",

--- a/src/sendEmail.ts
+++ b/src/sendEmail.ts
@@ -79,7 +79,7 @@ export const sendEmail = async <T extends BaseEmailData = BaseEmailData>(
     throw new Error('Field "to" is required for sending emails')
   }
 
-  if (!emailData.subject || emailData.subject === null || !emailData.html || emailData.html === null) {
+  if (!emailData.subject || !emailData.html) {
     throw new Error('Fields "subject" and "html" are required when not using a template')
   }
 
@@ -87,10 +87,10 @@ export const sendEmail = async <T extends BaseEmailData = BaseEmailData>(
   if (emailData.to) {
     emailData.to = parseAndValidateEmails(emailData.to as string | string[])
   }
-  if (emailData.cc && emailData.cc !== null) {
+  if (emailData.cc) {
     emailData.cc = parseAndValidateEmails(emailData.cc as string | string[])
   }
-  if (emailData.bcc && emailData.bcc !== null) {
+  if (emailData.bcc) {
     emailData.bcc = parseAndValidateEmails(emailData.bcc as string | string[])
   }
 

--- a/src/sendEmail.ts
+++ b/src/sendEmail.ts
@@ -2,15 +2,16 @@ import { Payload } from 'payload'
 import { getMailing, renderTemplate, parseAndValidateEmails } from './utils/helpers.js'
 
 // Base type for email data that all emails must have
+// Compatible with PayloadCMS generated types that include null
 export interface BaseEmailData {
   to: string | string[]
-  cc?: string | string[]
-  bcc?: string | string[]
-  subject?: string
-  html?: string
-  text?: string
-  scheduledAt?: string | Date
-  priority?: number
+  cc?: string | string[] | null
+  bcc?: string | string[] | null
+  subject?: string | null
+  html?: string | null
+  text?: string | null
+  scheduledAt?: string | Date | null
+  priority?: number | null
   [key: string]: any
 }
 
@@ -78,18 +79,18 @@ export const sendEmail = async <T extends BaseEmailData = BaseEmailData>(
     throw new Error('Field "to" is required for sending emails')
   }
 
-  if (!emailData.subject || !emailData.html) {
+  if (!emailData.subject || emailData.subject === null || !emailData.html || emailData.html === null) {
     throw new Error('Fields "subject" and "html" are required when not using a template')
   }
 
-  // Process email addresses using shared validation
+  // Process email addresses using shared validation (handle null values)
   if (emailData.to) {
     emailData.to = parseAndValidateEmails(emailData.to as string | string[])
   }
-  if (emailData.cc) {
+  if (emailData.cc && emailData.cc !== null) {
     emailData.cc = parseAndValidateEmails(emailData.cc as string | string[])
   }
-  if (emailData.bcc) {
+  if (emailData.bcc && emailData.bcc !== null) {
     emailData.bcc = parseAndValidateEmails(emailData.bcc as string | string[])
   }
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -5,8 +5,8 @@ import { TemplateVariables } from '../types/index.js'
  * Parse and validate email addresses
  * @internal
  */
-export const parseAndValidateEmails = (emails: string | string[] | undefined): string[] | undefined => {
-  if (!emails) return undefined
+export const parseAndValidateEmails = (emails: string | string[] | null | undefined): string[] | undefined => {
+  if (!emails || emails === null) return undefined
 
   let emailList: string[]
   if (Array.isArray(emails)) {


### PR DESCRIPTION
Resolves: TS2344: Type Email does not satisfy the constraint BaseEmailData
- Add null support to BaseEmailData interface for all optional fields
- Update parseAndValidateEmails to handle null values
- Update sendEmail validation to properly check for null values
- Maintain compatibility with PayloadCMS generated types that include null

Generated Email types like cc?: string[] | null | undefined now work correctly.

🤖 Generated with [Claude Code](https://claude.ai/code)