### PR TITLE
Refactor `sendEmail` to improve type safety and align with `BaseEmail…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xtr-dev/payload-mailing",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Template-based email system with scheduling and job processing for PayloadCMS",
   "type": "module",
   "main": "dist/index.js",

--- a/src/sendEmail.ts
+++ b/src/sendEmail.ts
@@ -1,9 +1,10 @@
 import { Payload } from 'payload'
 import { getMailing, renderTemplate, parseAndValidateEmails } from './utils/helpers.js'
 import {Email} from "./payload-types.js"
+import {BaseEmail} from "./types/index.js"
 
 // Options for sending emails
-export interface SendEmailOptions<T extends Email = Email> {
+export interface SendEmailOptions<T extends BaseEmail = BaseEmail> {
   // Template-based email
   template?: {
     slug: string
@@ -35,7 +36,7 @@ export interface SendEmailOptions<T extends Email = Email> {
  * })
  * ```
  */
-export const sendEmail = async <T extends Email = Email>(
+export const sendEmail = async <T extends BaseEmail = BaseEmail>(
   payload: Payload,
   options: SendEmailOptions<T>
 ): Promise<T> => {


### PR DESCRIPTION
…` interface

- Replace `Email` with `BaseEmail` for stricter type validation.
- Update `SendEmailOptions` and `sendEmail` typing for improved extensibility.