### PR TITLE
Align `sendEmail` and `sendEmailTask` with updated `BaseEmail` typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xtr-dev/payload-mailing",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Template-based email system with scheduling and job processing for PayloadCMS",
   "type": "module",
   "main": "dist/index.js",

--- a/src/jobs/sendEmailTask.ts
+++ b/src/jobs/sendEmailTask.ts
@@ -1,5 +1,6 @@
 import { sendEmail } from '../sendEmail.js'
 import { Email } from '../payload-types.js'
+import {BaseEmail} from "../types/index.js"
 
 export interface SendEmailTaskInput {
   // Template mode fields
@@ -116,6 +117,12 @@ export const sendEmailJob = {
       }
     }
   ],
+  outputSchema: [
+    {
+      name: 'id',
+      type: 'text' as const
+    }
+  ],
   handler: async ({ input, payload }: any) => {
     // Cast input to our expected type
     const taskInput = input as SendEmailTaskInput
@@ -154,18 +161,12 @@ export const sendEmailJob = {
       })
 
       // Use the sendEmail helper to create the email
-      const email = await sendEmail<Email>(payload, sendEmailOptions)
+      const email = await sendEmail<BaseEmail>(payload, sendEmailOptions)
 
       return {
         output: {
           success: true,
-          emailId: email.id,
-          message: `Email queued successfully with ID: ${email.id}`,
-          mode: taskInput.templateSlug ? 'template' : 'direct',
-          templateSlug: taskInput.templateSlug || null,
-          subject: email.subject,
-          recipients: Array.isArray(email.to) ? email.to.length : 1,
-          scheduledAt: email.scheduledAt || null
+          id: email.id,
         }
       }
 

--- a/src/sendEmail.ts
+++ b/src/sendEmail.ts
@@ -36,10 +36,10 @@ export interface SendEmailOptions<T extends BaseEmail = BaseEmail> {
  * })
  * ```
  */
-export const sendEmail = async <T extends BaseEmail = BaseEmail>(
+export const sendEmail = async <T extends BaseEmail = BaseEmail, ID = string | number>(
   payload: Payload,
   options: SendEmailOptions<T>
-): Promise<T> => {
+): Promise<T & {id: ID}> => {
   const mailing = getMailing(payload)
   const collectionSlug = options.collectionSlug || mailing.collections.emails || 'emails'
 
@@ -97,7 +97,7 @@ export const sendEmail = async <T extends BaseEmail = BaseEmail>(
     data: emailData
   })
 
-  return email as T
+  return email as T & {id: ID}
 }
 
 export default sendEmail


### PR DESCRIPTION
- Refactor `sendEmail` to return extended type with `id` for better type inference.
- Update `sendEmailTask` to use `BaseEmail` instead of `Email`.
- Add `outputSchema` in `sendEmailTask` for consistent output structure.