### PR TITLE
Fix variables field type to support all JSON-compatible values

### DIFF
--- a/CUSTOM-TYPES.md
+++ b/CUSTOM-TYPES.md
@@ -53,6 +53,9 @@ Your Payload configuration determines which types are used. The plugin automatic
 The base interfaces provided by the plugin:
 
 ```typescript
+// JSON value type that matches Payload's JSON field type
+type JSONValue = string | number | boolean | { [k: string]: unknown } | unknown[] | null | undefined
+
 interface BaseEmailDocument {
   id: string | number
   template?: any
@@ -64,7 +67,7 @@ interface BaseEmailDocument {
   subject: string
   html: string
   text?: string | null
-  variables?: Record<string, any> | null
+  variables?: JSONValue  // Supports any JSON-compatible value
   scheduledAt?: string | null
   sentAt?: string | null
   status?: 'pending' | 'processing' | 'sent' | 'failed' | null

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xtr-dev/payload-mailing",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Template-based email system with scheduling and job processing for PayloadCMS",
   "type": "module",
   "main": "dist/index.js",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,9 @@ import { Payload } from 'payload'
 import type { CollectionConfig, RichTextField } from 'payload'
 import { Transporter } from 'nodemailer'
 
+// JSON value type that matches Payload's JSON field type
+export type JSONValue = string | number | boolean | { [k: string]: unknown } | unknown[] | null | undefined
+
 // Generic base interfaces that work with any ID type and null values
 export interface BaseEmailDocument {
   id: string | number
@@ -14,7 +17,7 @@ export interface BaseEmailDocument {
   subject: string
   html: string
   text?: string | null
-  variables?: Record<string, any> | null
+  variables?: JSONValue
   scheduledAt?: string | null
   sentAt?: string | null
   status?: 'pending' | 'processing' | 'sent' | 'failed' | null
@@ -84,7 +87,7 @@ export interface QueuedEmail {
   subject: string
   html: string
   text?: string | null
-  variables?: Record<string, any> | null
+  variables?: JSONValue
   scheduledAt?: string | null
   sentAt?: string | null
   status: 'pending' | 'processing' | 'sent' | 'failed'


### PR DESCRIPTION
- Replace restrictive Record<string, any> with flexible JSONValue type for variables field
- Add JSONValue type alias that matches Payload's JSON field type specification
- Support string, number, boolean, objects, arrays, null, and undefined for variables
- Update both BaseEmailDocument and QueuedEmail interfaces consistently
- Update documentation to reflect JSONValue support

Fixes type constraint error where customer Email.variables field type (string | number | boolean | {...} | unknown[] | null | undefined) was not assignable to Record<string, any>.

🤖 Generated with [Claude Code](https://claude.ai/code)