### PR TITLE
Fix model overwrite error when plugin is initialized multiple times

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xtr-dev/payload-mailing",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Template-based email system with scheduling and job processing for PayloadCMS",
   "type": "module",
   "main": "dist/index.js",

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -144,6 +144,10 @@ export interface Email {
    */
   from?: string | null;
   /**
+   * Sender display name (optional, e.g., "John Doe" for "John Doe <john@example.com>")
+   */
+  fromName?: string | null;
+  /**
    * Reply-to email address
    */
   replyTo?: string | null;
@@ -336,6 +340,7 @@ export interface EmailsSelect<T extends boolean = true> {
   cc?: T;
   bcc?: T;
   from?: T;
+  fromName?: T;
   replyTo?: T;
   subject?: T;
   html?: T;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -74,10 +74,15 @@ export const mailingPlugin = (pluginConfig: MailingPluginConfig) => (config: Con
     }),
   } satisfies CollectionConfig
 
+  // Filter out any existing collections with the same slugs to prevent duplicates
+  const existingCollections = (config.collections || []).filter(
+    (collection) => collection.slug !== templatesSlug && collection.slug !== emailsSlug
+  )
+
   return {
     ...config,
     collections: [
-      ...(config.collections || []),
+      ...existingCollections,
       templatesCollection,
       emailsCollection,
     ],


### PR DESCRIPTION
- Filter out existing collections with same slugs before adding plugin collections
- Prevents 'Cannot overwrite model once compiled' errors in Next.js apps
- Fixes issue during hot reload and multiple getPayload() calls
- Bump version to 0.1.19