### PR TITLE
BREAKING CHANGE: Remove custom transport support, use Payload's email…

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,26 +28,31 @@ npm install @xtr-dev/payload-mailing
 
 ## Quick Start
 
-### 1. Add the plugin to your Payload config
+### 1. Configure email in your Payload config and add the plugin
 
 ```typescript
 import { buildConfig } from 'payload/config'
 import { mailingPlugin } from '@xtr-dev/payload-mailing'
+import { nodemailerAdapter } from '@payloadcms/email-nodemailer'
 
 export default buildConfig({
   // ... your config
+  email: nodemailerAdapter({
+    defaultFromAddress: 'noreply@yoursite.com',
+    defaultFromName: 'Your Site',
+    transport: {
+      host: 'smtp.gmail.com',
+      port: 587,
+      auth: {
+        user: process.env.EMAIL_USER,
+        pass: process.env.EMAIL_PASS,
+      },
+    },
+  }),
   plugins: [
     mailingPlugin({
       defaultFrom: 'noreply@yoursite.com',
-      transport: {
-        host: 'smtp.gmail.com',
-        port: 587,
-        secure: false,
-        auth: {
-          user: process.env.EMAIL_USER,
-          pass: process.env.EMAIL_PASS,
-        },
-      },
+      defaultFromName: 'Your Site Name',
       retryAttempts: 3,
       retryDelay: 300000, // 5 minutes
       queue: 'email-queue', // optional
@@ -117,13 +122,6 @@ mailingPlugin({
   // Custom template renderer (optional)
   templateRenderer: async (template: string, variables: Record<string, any>) => {
     return yourCustomEngine.render(template, variables)
-  },
-
-  // Email transport
-  transport: {
-    host: 'smtp.gmail.com',
-    port: 587,
-    auth: { user: '...', pass: '...' }
   },
 
   // Collection names (optional)

--- a/dev/payload.config.ts
+++ b/dev/payload.config.ts
@@ -135,15 +135,6 @@ const buildConfigWithMemoryDB = async () => {
       mailingPlugin({
         defaultFrom: 'noreply@test.com',
         initOrder: 'after',
-        transport: {
-          host: 'localhost',
-          port: 1025, // MailHog port for dev
-          secure: false,
-          auth: {
-            user: 'test',
-            pass: 'test',
-          },
-        },
         retryAttempts: 3,
         retryDelay: 60000, // 1 minute for dev
         queue: 'email-queue',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xtr-dev/payload-mailing",
-  "version": "0.1.24",
+  "version": "0.2.0",
   "description": "Template-based email system with scheduling and job processing for PayloadCMS",
   "type": "module",
   "main": "dist/index.js",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,5 @@
 import { Payload } from 'payload'
 import type { CollectionConfig, RichTextField } from 'payload'
-import { Transporter } from 'nodemailer'
 
 // JSON value type that matches Payload's JSON field type
 export type JSONValue = string | number | boolean | { [k: string]: unknown } | unknown[] | null | undefined
@@ -70,7 +69,6 @@ export interface MailingPluginConfig {
   }
   defaultFrom?: string
   defaultFromName?: string
-  transport?: Transporter | MailingTransportConfig
   queue?: string
   retryAttempts?: number
   retryDelay?: number
@@ -81,17 +79,6 @@ export interface MailingPluginConfig {
   onReady?: (payload: any) => Promise<void>
   initOrder?: 'before' | 'after'
 }
-
-export interface MailingTransportConfig {
-  host: string
-  port: number
-  secure?: boolean
-  auth?: {
-    user: string
-    pass: string
-  }
-}
-
 
 export interface QueuedEmail {
   id: string


### PR DESCRIPTION
… config

- Removed custom transport configuration from plugin
- Plugin now requires Payload email to be configured
- Simplified setup by relying on Payload's email adapter
- Updated README with new configuration requirements
- Bump version to 0.2.0 (breaking change)

Users must now configure email in their Payload config using an email adapter like @payloadcms/email-nodemailer instead of configuring transport in the plugin.