### PR TITLE
Fix TypeScript build error in jobScheduler.ts

### DIFF
--- a/src/utils/jobScheduler.ts
+++ b/src/utils/jobScheduler.ts
@@ -73,8 +73,8 @@ export async function ensureEmailJob(
       jobId: job.id,
       emailId: normalizedEmailId,
       scheduledAt: options?.scheduledAt || 'immediate',
-      task: job.task,
-      queue: job.queue
+      task: 'process-email',
+      queue: queueName
     })
 
     return {


### PR DESCRIPTION
- Use static values for task and queue in logging instead of accessing job properties
- Properties 'task' and 'queue' don't exist on BaseJob type

🤖 Generated with [Claude Code](https://claude.ai/code)