### PR TITLE
Fix template population in beforeSend hook and bump version to 0.4.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xtr-dev/payload-mailing",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "description": "Template-based email system with scheduling and job processing for PayloadCMS",
   "type": "module",
   "main": "dist/index.js",

--- a/src/services/MailingService.ts
+++ b/src/services/MailingService.ts
@@ -233,6 +233,7 @@ export class MailingService implements IMailingService {
       const email = await this.payload.findByID({
         collection: this.emailsCollection as any,
         id: emailId,
+        depth: 1,
       }) as BaseEmailDocument
 
       // Combine from and fromName for nodemailer using proper sanitization


### PR DESCRIPTION
Added depth parameter to findByID call in processEmailItem to ensure template relationship is populated when passed to beforeSend hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)