### PR TITLE
Add templateSlug field auto-populated from template relationship and …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xtr-dev/payload-mailing",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "description": "Template-based email system with scheduling and job processing for PayloadCMS",
   "type": "module",
   "main": "dist/index.js",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,6 +14,7 @@ export type JSONValue = string | number | boolean | { [k: string]: unknown } | u
 export interface BaseEmailDocument {
   id: string | number
   template?: any
+  templateSlug?: string | null
   to: string[]
   cc?: string[] | null
   bcc?: string[] | null


### PR DESCRIPTION
…bump version to 0.4.17

Added templateSlug text field to Emails collection that is automatically populated via beforeChange hook when template relationship is set, making template slug accessible in beforeSend hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)