### PR TITLE
Fix template relationship population in sendEmail and bump version to…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xtr-dev/payload-mailing",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "description": "Template-based email system with scheduling and job processing for PayloadCMS",
   "type": "module",
   "main": "dist/index.js",

--- a/src/services/MailingService.ts
+++ b/src/services/MailingService.ts
@@ -127,6 +127,17 @@ export class MailingService implements IMailingService {
       throw new Error(`Email template not found: ${templateSlug}`)
     }
 
+    return this.renderTemplateDocument(template, variables)
+  }
+
+  /**
+   * Render a template document (for when you already have the template loaded)
+   * This avoids duplicate template lookups
+   * @internal
+   */
+  async renderTemplateDocument(template: BaseEmailTemplateDocument, variables: TemplateVariables): Promise<{ html: string; text: string; subject: string }> {
+    this.ensureInitialized()
+
     const emailContent = await this.renderEmailTemplate(template, variables)
     const subject = await this.renderTemplateString(template.subject || '', variables)
 


### PR DESCRIPTION
… 0.4.18

The sendEmail function now properly populates the template relationship field when using template-based emails. This ensures:
- Template relationship is set on the email document
- templateSlug field is auto-populated via beforeChange hook
- beforeSend hook has access to the full template relationship
- Proper record of which template was used for each email

🤖 Generated with [Claude Code](https://claude.com/claude-code)