### PR TITLE
Fix ObjectId casting error when jobs relationship is populated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xtr-dev/payload-mailing",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "description": "Template-based email system with scheduling and job processing for PayloadCMS",
   "type": "module",
   "main": "dist/index.js",

--- a/src/utils/jobScheduler.ts
+++ b/src/utils/jobScheduler.ts
@@ -129,7 +129,11 @@ export async function updateEmailJobRelationship(
       id: normalizedEmailId,
     })
 
-    const currentJobs = (currentEmail.jobs || []).map((job: any) => String(job))
+    // Extract IDs from job objects or use the value directly if it's already an ID
+    // Jobs can be populated (objects with id field) or just IDs (strings/numbers)
+    const currentJobs = (currentEmail.jobs || []).map((job: any) =>
+      typeof job === 'object' && job !== null && job.id ? String(job.id) : String(job)
+    )
     const allJobs = [...new Set([...currentJobs, ...normalizedJobIds])] // Deduplicate with normalized strings
 
     await payload.update({


### PR DESCRIPTION
When the email's jobs relationship is populated with full job objects instead of just IDs, calling String(job) on an object results in "[object Object]", which causes a Mongoose ObjectId casting error. This fix properly extracts the ID from job objects or uses the value directly if it's already an ID.

Fixes job scheduler error: "Cast to ObjectId failed for value '[object Object]'"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

closes #66 