### PR TITLE
Fix filterOptions ObjectId casting error and bump version to 0.4.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xtr-dev/payload-mailing",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "description": "Template-based email system with scheduling and job processing for PayloadCMS",
   "type": "module",
   "main": "dist/index.js",

--- a/src/collections/Emails.ts
+++ b/src/collections/Emails.ts
@@ -206,7 +206,7 @@ const Emails: CollectionConfig = {
         readOnly: true,
       },
       filterOptions: ({ id }) => {
-        const emailId = resolveID({ id })
+        const emailId = resolveID(id)
         return {
           'input.emailId': {
             equals: emailId ? String(emailId) : '',


### PR DESCRIPTION
Fixed incorrect usage of resolveID in filterOptions where { id } was passed instead of id directly. This caused ObjectId casting errors when the id parameter was a populated object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)