### PR TITLE
refactor: simplify LiquidJS init guard

### DIFF
--- a/src/services/MailingService.ts
+++ b/src/services/MailingService.ts
@@ -54,7 +54,7 @@ export class MailingService implements IMailingService {
       this.liquid = new LiquidEngine()
 
       // Register custom filters (equivalent to Handlebars helpers)
-      if (this.liquid && typeof this.liquid !== 'boolean') {
+      if (this.liquid) {
         this.liquid.registerFilter('formatDate', (date: any, format?: string) => {
           if (!date) {return ''}
           const d = new Date(date)


### PR DESCRIPTION
Simplifies the LiquidJS initialization guard in `MailingService`.

The `typeof this.liquid !== 'boolean'` check was redundant — `false` is already falsy, so `if (this.liquid)` is sufficient and additionally narrows the type to the `Liquid` instance for the `registerFilter` calls.

No behavior change. This validates the new single-branch CI flow (`ci.yml` runs; `version-check.yml` should pass since there's no version bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)