### PR TITLE
chore: add ESLint flat config and conform src

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,18 @@
+import { rootEslintConfig } from '@payloadcms/eslint-config'
+
+/** @type {import('eslint').Linter.Config[]} */
+export default [
+  ...rootEslintConfig,
+  {
+    languageOptions: {
+      parserOptions: {
+        // Enable type-aware linting using the nearest tsconfig.
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+  {
+    ignores: ['dist/**', 'dev/**', 'node_modules/**', '**/*.js', '**/*.mjs', '**/*.cjs'],
+  },
+]

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dev:generate-importmap": "npm run dev:payload generate:importmap",
     "dev:generate-types": "npm run dev:payload generate:types",
     "dev:payload": "cross-env PAYLOAD_CONFIG_PATH=./dev/payload.config.ts payload",
-    "lint": "eslint",
+    "lint": "eslint ./src",
     "lint:fix": "eslint ./src --fix",
     "prepublishOnly": "npm run clean && npm run build",
     "test": "echo 'Tests temporarily disabled during development'",

--- a/src/collections/EmailTemplates.ts
+++ b/src/collections/EmailTemplates.ts
@@ -1,27 +1,26 @@
 import type { CollectionConfig, RichTextField } from 'payload'
+
 import { lexicalEditor } from '@payloadcms/richtext-lexical'
 
 export const createEmailTemplatesCollection = (editor?: RichTextField['editor']): CollectionConfig => ({
   slug: 'email-templates',
   admin: {
-    useAsTitle: 'name',
     defaultColumns: ['name', 'subject', 'updatedAt'],
     group: 'Mailing',
+    useAsTitle: 'name',
   },
   fields: [
     {
       name: 'name',
       type: 'text',
-      required: true,
       admin: {
         description: 'A descriptive name for this email template',
       },
+      required: true,
     },
     {
       name: 'slug',
       type: 'text',
-      required: true,
-      unique: true,
       admin: {
         description: 'Unique identifier for this template (e.g., "welcome-email", "password-reset")',
       },
@@ -35,27 +34,29 @@ export const createEmailTemplatesCollection = (editor?: RichTextField['editor'])
           },
         ],
       },
+      required: true,
+      unique: true,
     },
     {
       name: 'subject',
       type: 'text',
-      required: true,
       admin: {
         description: 'Email subject line. You can use Handlebars variables like {{firstName}} or {{siteName}}.',
       },
+      required: true,
     },
     {
       name: 'content',
       type: 'richText',
-      required: true,
+      admin: {
+        description: 'Email content with rich text formatting. Supports Handlebars variables like {{firstName}} and helpers like {{formatDate createdAt "long"}}. Content is converted to HTML and plain text automatically.',
+      },
       editor: editor || lexicalEditor({
         features: ({ defaultFeatures }) => [
           ...defaultFeatures,
         ],
       }),
-      admin: {
-        description: 'Email content with rich text formatting. Supports Handlebars variables like {{firstName}} and helpers like {{formatDate createdAt "long"}}. Content is converted to HTML and plain text automatically.',
-      },
+      required: true,
     },
   ],
   timestamps: true,

--- a/src/collections/Emails.ts
+++ b/src/collections/Emails.ts
@@ -1,44 +1,45 @@
 import type { CollectionConfig } from 'payload'
+
+import { resolveID } from '../utils/helpers.js'
 import { ensureEmailJob } from '../utils/jobScheduler.js'
 import { createContextLogger } from '../utils/logger.js'
-import { resolveID } from '../utils/helpers.js'
 
 const Emails: CollectionConfig = {
   slug: 'emails',
   admin: {
-    useAsTitle: 'subject',
     defaultColumns: ['subject', 'to', 'status', 'jobs', 'scheduledAt', 'sentAt'],
-    group: 'Mailing',
     description: 'Email delivery and status tracking',
+    group: 'Mailing',
+    useAsTitle: 'subject',
   },
   defaultPopulate: {
-    templateSlug: true,
-    to: true,
-    cc: true,
-    bcc: true,
-    from: true,
-    replyTo: true,
-    jobs: true,
-    status: true,
     attempts: true,
-    lastAttemptAt: true,
+    bcc: true,
+    cc: true,
+    createdAt: true,
     error: true,
+    from: true,
+    html: true,
+    jobs: true,
+    lastAttemptAt: true,
     priority: true,
+    replyTo: true,
     scheduledAt: true,
     sentAt: true,
-    variables: true,
-    html: true,
+    status: true,
+    templateSlug: true,
     text: true,
-    createdAt: true,
+    to: true,
+    variables: true,
   },
   fields: [
     {
       name: 'template',
       type: 'relationship',
-      relationTo: 'email-templates' as const,
       admin: {
         description: 'Email template used (optional if custom content provided)',
       },
+      relationTo: 'email-templates' as const,
     },
     {
       name: 'templateSlug',
@@ -51,27 +52,27 @@ const Emails: CollectionConfig = {
     {
       name: 'to',
       type: 'text',
-      required: true,
-      hasMany: true,
       admin: {
         description: 'Recipient email addresses',
       },
+      hasMany: true,
+      required: true,
     },
     {
       name: 'cc',
       type: 'text',
-      hasMany: true,
       admin: {
         description: 'CC email addresses',
       },
+      hasMany: true,
     },
     {
       name: 'bcc',
       type: 'text',
-      hasMany: true,
       admin: {
         description: 'BCC email addresses',
       },
+      hasMany: true,
     },
     {
       name: 'from',
@@ -97,19 +98,19 @@ const Emails: CollectionConfig = {
     {
       name: 'subject',
       type: 'text',
-      required: true,
       admin: {
         description: 'Email subject line',
       },
+      required: true,
     },
     {
       name: 'html',
       type: 'textarea',
-      required: true,
       admin: {
         description: 'Rendered HTML content of the email',
         rows: 8,
       },
+      required: true,
     },
     {
       name: 'text',
@@ -130,53 +131,53 @@ const Emails: CollectionConfig = {
       name: 'scheduledAt',
       type: 'date',
       admin: {
-        description: 'When this email should be sent (leave empty for immediate)',
         date: {
           pickerAppearance: 'dayAndTime',
         },
+        description: 'When this email should be sent (leave empty for immediate)',
       },
     },
     {
       name: 'sentAt',
       type: 'date',
       admin: {
-        description: 'When this email was actually sent',
         date: {
           pickerAppearance: 'dayAndTime',
         },
+        description: 'When this email was actually sent',
       },
     },
     {
       name: 'status',
       type: 'select',
-      required: true,
+      admin: {
+        description: 'Current status of this email',
+      },
+      defaultValue: 'pending',
       options: [
         { label: 'Pending', value: 'pending' },
         { label: 'Processing', value: 'processing' },
         { label: 'Sent', value: 'sent' },
         { label: 'Failed', value: 'failed' },
       ],
-      defaultValue: 'pending',
-      admin: {
-        description: 'Current status of this email',
-      },
+      required: true,
     },
     {
       name: 'attempts',
       type: 'number',
-      defaultValue: 0,
       admin: {
         description: 'Number of send attempts made',
       },
+      defaultValue: 0,
     },
     {
       name: 'lastAttemptAt',
       type: 'date',
       admin: {
-        description: 'When the last send attempt was made',
         date: {
           pickerAppearance: 'dayAndTime',
         },
+        description: 'When the last send attempt was made',
       },
     },
     {
@@ -190,19 +191,17 @@ const Emails: CollectionConfig = {
     {
       name: 'priority',
       type: 'number',
-      defaultValue: 5,
       admin: {
         description: 'Email priority (1=highest, 10=lowest)',
       },
+      defaultValue: 5,
     },
     {
       name: 'jobs',
       type: 'relationship',
-      relationTo: 'payload-jobs',
-      hasMany: true,
       admin: {
-        description: 'Processing jobs associated with this email',
         allowCreate: false,
+        description: 'Processing jobs associated with this email',
         readOnly: true,
       },
       filterOptions: ({ id }) => {
@@ -213,6 +212,8 @@ const Emails: CollectionConfig = {
           },
         }
       },
+      hasMany: true,
+      relationTo: 'payload-jobs',
     },
   ],
   hooks: {
@@ -222,8 +223,8 @@ const Emails: CollectionConfig = {
         if (data.template) {
           try {
             const template = await req.payload.findByID({
-              collection: 'email-templates',
               id: typeof data.template === 'string' ? data.template : data.template.id,
+              collection: 'email-templates',
             })
             data.templateSlug = template.slug
           } catch (error) {
@@ -240,7 +241,7 @@ const Emails: CollectionConfig = {
     // Simple approach: Only use afterChange hook for job management
     // This avoids complex interaction between hooks and ensures document ID is always available
     afterChange: [
-      async ({ doc, previousDoc, req, operation }) => {
+      async ({ doc, operation, previousDoc, req }) => {
         // Skip if:
         // 1. Email is not pending status
         // 2. Jobs are not configured
@@ -277,7 +278,6 @@ const Emails: CollectionConfig = {
       }
     ]
   },
-  timestamps: true,
   indexes: [
     {
       fields: ['status', 'scheduledAt'],
@@ -286,6 +286,7 @@ const Emails: CollectionConfig = {
       fields: ['priority', 'createdAt'],
     },
   ],
+  timestamps: true,
 }
 
 export default Emails

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,37 +1,37 @@
-// Main plugin export
-export { mailingPlugin, default as mailingPluginDefault } from './plugin.js'
-
-// Types
-export * from './types/index.js'
-
-// Services
-export { MailingService } from './services/MailingService.js'
+export { default as Emails } from './collections/Emails.js'
 
 // Collections
-export { default as EmailTemplates, createEmailTemplatesCollection } from './collections/EmailTemplates.js'
-export { default as Emails } from './collections/Emails.js'
+export { createEmailTemplatesCollection, default as EmailTemplates } from './collections/EmailTemplates.js'
 
 // Jobs (includes the individual email processing job)
 export { mailingJobs } from './jobs/index.js'
+
 export type { ProcessEmailJobInput } from './jobs/processEmailJob.js'
+// Main plugin export
+export { default as mailingPluginDefault, mailingPlugin } from './plugin.js'
 
 // Main email sending function
 export { sendEmail, type SendEmailOptions } from './sendEmail.js'
 export { default as sendEmailDefault } from './sendEmail.js'
 
+// Services
+export { MailingService } from './services/MailingService.js'
+// Types
+export * from './types/index.js'
+
+// Email processing utilities
+export { processAllEmails, processEmailById, processJobById } from './utils/emailProcessor.js'
+
 // Utility functions for developers
 export {
   getMailing,
-  renderTemplate,
-  processEmails,
-  retryFailedEmails,
   parseAndValidateEmails,
+  processEmails,
+  renderTemplate,
+  retryFailedEmails,
   sanitizeDisplayName,
   sanitizeFromName,
 } from './utils/helpers.js'
 
-// Email processing utilities
-export { processEmailById, processJobById, processAllEmails } from './utils/emailProcessor.js'
-
 // Job scheduling utilities
-export { findExistingJobs, ensureEmailJob, updateEmailJobRelationship } from './utils/jobScheduler.js'
+export { ensureEmailJob, findExistingJobs, updateEmailJobRelationship } from './utils/jobScheduler.js'

--- a/src/jobs/processEmailJob.ts
+++ b/src/jobs/processEmailJob.ts
@@ -1,4 +1,5 @@
 import type { PayloadRequest } from 'payload'
+
 import { processEmailById } from '../utils/emailProcessor.js'
 
 /**
@@ -8,7 +9,7 @@ export interface ProcessEmailJobInput {
   /**
    * The ID of the email to process
    */
-  emailId: string | number
+  emailId: number | string
 }
 
 /**
@@ -16,32 +17,6 @@ export interface ProcessEmailJobInput {
  */
 export const processEmailJob = {
   slug: 'process-email',
-  label: 'Process Individual Email',
-  inputSchema: [
-    {
-      name: 'emailId',
-      type: 'text' as const,
-      required: true,
-      label: 'Email ID',
-      admin: {
-        description: 'The ID of the email to process and send'
-      }
-    }
-  ],
-  outputSchema: [
-    {
-      name: 'success',
-      type: 'checkbox' as const
-    },
-    {
-      name: 'emailId',
-      type: 'text' as const
-    },
-    {
-      name: 'status',
-      type: 'text' as const
-    }
-  ],
   handler: async ({ input, req }: { input: ProcessEmailJobInput; req: PayloadRequest }) => {
     const payload = (req as any).payload
     const { emailId } = input
@@ -56,16 +31,42 @@ export const processEmailJob = {
 
       return {
         output: {
-          success: true,
           emailId: String(emailId),
+          message: `Email ${emailId} processed successfully`,
           status: 'sent',
-          message: `Email ${emailId} processed successfully`
+          success: true
         }
       }
     } catch (error) {
       throw new Error(`Failed to process email ${emailId}: ${String(error)}`)
     }
-  }
+  },
+  inputSchema: [
+    {
+      name: 'emailId',
+      type: 'text' as const,
+      admin: {
+        description: 'The ID of the email to process and send'
+      },
+      label: 'Email ID',
+      required: true
+    }
+  ],
+  label: 'Process Individual Email',
+  outputSchema: [
+    {
+      name: 'success',
+      type: 'checkbox' as const
+    },
+    {
+      name: 'emailId',
+      type: 'text' as const
+    },
+    {
+      name: 'status',
+      type: 'text' as const
+    }
+  ]
 }
 
 export default processEmailJob

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,9 +1,11 @@
 import type {CollectionConfig, Config, Field} from 'payload'
-import { MailingPluginConfig, MailingContext } from './types/index.js'
-import { MailingService } from './services/MailingService.js'
-import { createEmailTemplatesCollection } from './collections/EmailTemplates.js'
+
+import type { MailingContext, MailingPluginConfig } from './types/index.js'
+
 import Emails from './collections/Emails.js'
+import { createEmailTemplatesCollection } from './collections/EmailTemplates.js'
 import { mailingJobs } from './jobs/index.js'
+import { MailingService } from './services/MailingService.js'
 
 
 export const mailingPlugin = (pluginConfig: MailingPluginConfig) => (config: Config): Config => {
@@ -96,14 +98,14 @@ export const mailingPlugin = (pluginConfig: MailingPluginConfig) => (config: Con
       const mailingService = new MailingService(payload, pluginConfig)
 
       // Add mailing context to payload for developer access
-      ;(payload as any).mailing = {
+      ;(payload).mailing = {
+        collections: {
+          emails: emailsSlug,
+          templates: templatesSlug,
+        },
+        config: pluginConfig,
         payload,
         service: mailingService,
-        config: pluginConfig,
-        collections: {
-          templates: templatesSlug,
-          emails: emailsSlug,
-        },
       } as MailingContext
 
       if (pluginConfig.initOrder !== 'after' && config.onInit) {

--- a/src/sendEmail.ts
+++ b/src/sendEmail.ts
@@ -1,23 +1,25 @@
-import { Payload } from 'payload'
-import { getMailing, renderTemplateWithId, parseAndValidateEmails, sanitizeFromName } from './utils/helpers.js'
-import { BaseEmailDocument } from './types/index.js'
+import type { Payload } from 'payload'
+
+import type { BaseEmailDocument } from './types/index.js'
+
 import { processJobById } from './utils/emailProcessor.js'
-import { createContextLogger } from './utils/logger.js'
+import { getMailing, parseAndValidateEmails, renderTemplateWithId, sanitizeFromName } from './utils/helpers.js'
 import { pollForJobId } from './utils/jobPolling.js'
+import { createContextLogger } from './utils/logger.js'
 
 // Options for sending emails
 export interface SendEmailOptions<T extends BaseEmailDocument = BaseEmailDocument> {
+  // Common options
+  collectionSlug?: string // defaults to 'emails'
+  // Direct email data
+  data?: Partial<T>
+  processImmediately?: boolean // if true, creates job and processes it immediately
+  queue?: string // queue name for the job, defaults to mailing config queue
   // Template-based email
   template?: {
     slug: string
     variables?: Record<string, any>
   }
-  // Direct email data
-  data?: Partial<T>
-  // Common options
-  collectionSlug?: string // defaults to 'emails'
-  processImmediately?: boolean // if true, creates job and processes it immediately
-  queue?: string // queue name for the job, defaults to mailing config queue
 }
 
 /**
@@ -51,7 +53,7 @@ export const sendEmail = async <TEmail extends BaseEmailDocument = BaseEmailDocu
 
   if (options.template) {
     // Look up and render the template in a single operation to avoid duplicate lookups
-    const { html, text, subject, templateId } = await renderTemplateWithId(
+    const { html, subject, templateId, text } = await renderTemplateWithId(
       payload,
       options.template.slug,
       options.template.variables || {}
@@ -59,9 +61,9 @@ export const sendEmail = async <TEmail extends BaseEmailDocument = BaseEmailDocu
 
     emailData = {
       ...emailData,
-      template: templateId,
-      subject,
       html,
+      subject,
+      template: templateId,
       text,
       variables: options.template.variables || {},
     } as Partial<TEmail>
@@ -136,11 +138,11 @@ export const sendEmail = async <TEmail extends BaseEmailDocument = BaseEmailDocu
 
     // Poll for the job ID using configurable polling mechanism
     const { jobId } = await pollForJobId({
-      payload,
       collectionSlug,
-      emailId: email.id,
       config: mailingConfig.jobPolling,
+      emailId: email.id,
       logger,
+      payload,
     })
 
     try {

--- a/src/services/MailingService.ts
+++ b/src/services/MailingService.ts
@@ -1,20 +1,24 @@
-import {CollectionSlug, EmailAdapter, Payload, SendEmailOptions} from 'payload'
-import { Liquid } from 'liquidjs'
-import {
-  MailingPluginConfig,
-  TemplateVariables,
+import type { Liquid } from 'liquidjs'
+import type {CollectionSlug, Payload, SendEmailOptions} from 'payload';
+
+import { EmailAdapter} from 'payload'
+
+import type {
+  BaseEmailDocument,
+  BaseEmailTemplateDocument,
   MailingService as IMailingService,
-  BaseEmailDocument, BaseEmailTemplateDocument
+  MailingPluginConfig, TemplateVariables
 } from '../types/index.js'
-import { serializeRichTextToHTML, serializeRichTextToText } from '../utils/richTextSerializer.js'
+
 import { sanitizeDisplayName } from '../utils/helpers.js'
+import { serializeRichTextToHTML, serializeRichTextToText } from '../utils/richTextSerializer.js'
 
 export class MailingService implements IMailingService {
-  public payload: Payload
   private config: MailingPluginConfig
-  private templatesCollection: string
   private emailsCollection: string
-  private liquid: Liquid | null | false = null
+  private liquid: false | Liquid | null = null
+  private templatesCollection: string
+  public payload: Payload
 
   constructor(payload: Payload, config: MailingPluginConfig) {
     this.payload = payload
@@ -41,18 +45,55 @@ export class MailingService implements IMailingService {
     }
   }
 
-  /**
-   * Sanitizes a display name for use in email headers to prevent header injection
-   * Uses the centralized sanitization utility with quote escaping for headers
-   */
-  private sanitizeDisplayName(name: string): string {
-    return sanitizeDisplayName(name, true) // escapeQuotes = true for email headers
+  private async ensureLiquidJSInitialized(): Promise<void> {
+    if (this.liquid !== null) {return} // Already initialized or failed
+
+    try {
+      const liquidModule = await import('liquidjs')
+      const { Liquid: LiquidEngine } = liquidModule
+      this.liquid = new LiquidEngine()
+
+      // Register custom filters (equivalent to Handlebars helpers)
+      if (this.liquid && typeof this.liquid !== 'boolean') {
+        this.liquid.registerFilter('formatDate', (date: any, format?: string) => {
+          if (!date) {return ''}
+          const d = new Date(date)
+          if (format === 'short') {
+            return d.toLocaleDateString()
+          }
+          if (format === 'long') {
+            return d.toLocaleDateString('en-US', {
+              day: 'numeric',
+              month: 'long',
+              year: 'numeric'
+            })
+          }
+          return d.toLocaleString()
+        })
+
+        this.liquid.registerFilter('formatCurrency', (amount: any, currency = 'USD') => {
+          if (typeof amount !== 'number') {return amount}
+          return new Intl.NumberFormat('en-US', {
+            currency,
+            style: 'currency'
+          }).format(amount)
+        })
+
+        this.liquid.registerFilter('capitalize', (str: any) => {
+          if (typeof str !== 'string') {return str}
+          return str.charAt(0).toUpperCase() + str.slice(1)
+        })
+      }
+    } catch (error) {
+      console.warn('LiquidJS not available. Falling back to simple variable replacement. Install liquidjs or use a different templateEngine.')
+      this.liquid = false // Mark as failed to avoid retries
+    }
   }
 
   /**
    * Formats an email address with optional display name
    */
-  private formatEmailAddress(email: string, displayName?: string | null): string {
+  private formatEmailAddress(email: string, displayName?: null | string): string {
     if (displayName && displayName.trim()) {
       const sanitizedName = this.sanitizeDisplayName(displayName)
       return `"${sanitizedName}" <${email}>`
@@ -72,279 +113,36 @@ export class MailingService implements IMailingService {
     return fromEmail || ''
   }
 
-  private async ensureLiquidJSInitialized(): Promise<void> {
-    if (this.liquid !== null) return // Already initialized or failed
-
+  private async getTemplateBySlug(templateSlug: string): Promise<BaseEmailTemplateDocument | null> {
     try {
-      const liquidModule = await import('liquidjs')
-      const { Liquid: LiquidEngine } = liquidModule
-      this.liquid = new LiquidEngine()
+      const { docs } = await this.payload.find({
+        collection: this.templatesCollection as any,
+        limit: 1,
+        where: {
+          slug: {
+            equals: templateSlug,
+          },
+        },
+      })
 
-      // Register custom filters (equivalent to Handlebars helpers)
-      if (this.liquid && typeof this.liquid !== 'boolean') {
-        this.liquid.registerFilter('formatDate', (date: any, format?: string) => {
-          if (!date) return ''
-          const d = new Date(date)
-          if (format === 'short') {
-            return d.toLocaleDateString()
-          }
-          if (format === 'long') {
-            return d.toLocaleDateString('en-US', {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric'
-            })
-          }
-          return d.toLocaleString()
-        })
-
-        this.liquid.registerFilter('formatCurrency', (amount: any, currency = 'USD') => {
-          if (typeof amount !== 'number') return amount
-          return new Intl.NumberFormat('en-US', {
-            style: 'currency',
-            currency: currency
-          }).format(amount)
-        })
-
-        this.liquid.registerFilter('capitalize', (str: any) => {
-          if (typeof str !== 'string') return str
-          return str.charAt(0).toUpperCase() + str.slice(1)
-        })
-      }
+      return docs.length > 0 ? docs[0] as BaseEmailTemplateDocument : null
     } catch (error) {
-      console.warn('LiquidJS not available. Falling back to simple variable replacement. Install liquidjs or use a different templateEngine.')
-      this.liquid = false // Mark as failed to avoid retries
-    }
-  }
-
-  async renderTemplate(templateSlug: string, variables: TemplateVariables): Promise<{ html: string; text: string; subject: string }> {
-    this.ensureInitialized()
-    const template = await this.getTemplateBySlug(templateSlug)
-
-    if (!template) {
-      throw new Error(`Email template not found: ${templateSlug}`)
-    }
-
-    return this.renderTemplateDocument(template, variables)
-  }
-
-  /**
-   * Render a template document (for when you already have the template loaded)
-   * This avoids duplicate template lookups
-   * @internal
-   */
-  async renderTemplateDocument(template: BaseEmailTemplateDocument, variables: TemplateVariables): Promise<{ html: string; text: string; subject: string }> {
-    this.ensureInitialized()
-
-    const emailContent = await this.renderEmailTemplate(template, variables)
-    const subject = await this.renderTemplateString(template.subject || '', variables)
-
-    return {
-      html: emailContent.html,
-      text: emailContent.text,
-      subject
-    }
-  }
-
-  async processEmails(): Promise<void> {
-    this.ensureInitialized()
-    const currentTime = new Date().toISOString()
-
-    const { docs: pendingEmails } = await this.payload.find({
-      collection: this.emailsCollection as CollectionSlug,
-      where: {
-        and: [
-          {
-            status: {
-              equals: 'pending',
-            },
-          },
-          {
-            or: [
-              {
-                scheduledAt: {
-                  exists: false,
-                },
-              },
-              {
-                scheduledAt: {
-                  less_than_equal: currentTime,
-                },
-              },
-            ],
-          },
-        ],
-      },
-      sort: 'priority,-createdAt',
-      limit: 50,
-    })
-
-    for (const email of pendingEmails) {
-      await this.processEmailItem(String(email.id))
-    }
-  }
-
-  async retryFailedEmails(): Promise<void> {
-    this.ensureInitialized()
-    const maxAttempts = this.config.retryAttempts || 3
-    const retryDelay = this.config.retryDelay || 300000 // 5 minutes
-    const retryTime = new Date(Date.now() - retryDelay).toISOString()
-
-    const { docs: failedEmails } = await this.payload.find({
-      collection: this.emailsCollection as CollectionSlug,
-      where: {
-        and: [
-          {
-            status: {
-              equals: 'failed',
-            },
-          },
-          {
-            attempts: {
-              less_than: maxAttempts,
-            },
-          },
-          {
-            or: [
-              {
-                lastAttemptAt: {
-                  exists: false,
-                },
-              },
-              {
-                lastAttemptAt: {
-                  less_than: retryTime,
-                },
-              },
-            ],
-          },
-        ],
-      },
-      limit: 20,
-    })
-
-    for (const email of failedEmails) {
-      await this.processEmailItem(String(email.id))
-    }
-  }
-
-  async processEmailItem(emailId: string): Promise<void> {
-    try {
-      await this.payload.update({
-        collection: this.emailsCollection as CollectionSlug,
-        id: emailId,
-        data: {
-          status: 'processing',
-          lastAttemptAt: new Date().toISOString(),
-        },
-      })
-
-      const email = await this.payload.findByID({
-        collection: this.emailsCollection as CollectionSlug,
-        id: emailId,
-        depth: 1,
-      }) as BaseEmailDocument
-
-      // Combine from and fromName for nodemailer using proper sanitization
-      let fromField: string
-      if (email.from) {
-        fromField = this.formatEmailAddress(email.from, email.fromName)
-      } else {
-        fromField = this.getDefaultFrom()
-      }
-
-      let mailOptions: SendEmailOptions = {
-        from: fromField,
-        to: email.to,
-        cc: email.cc || undefined,
-        bcc: email.bcc || undefined,
-        replyTo: email.replyTo || undefined,
-        subject: email.subject,
-        html: email.html,
-        text: email.text || undefined,
-      }
-
-      if (!mailOptions.from) {
-        throw new Error('Email from field is required')
-      }
-      if (!mailOptions.to || (Array.isArray(mailOptions.to) && mailOptions.to.length === 0)) {
-        throw new Error('Email to field is required')
-      }
-      if (!mailOptions.subject) {
-        throw new Error('Email subject is required')
-      }
-      if (!mailOptions.html && !mailOptions.text) {
-        throw new Error('Email content is required')
-      }
-
-      // Call beforeSend hook if configured
-      if (this.config.beforeSend) {
-        try {
-          mailOptions = await this.config.beforeSend(mailOptions, email)
-
-          // Validate required properties remain intact after hook execution
-          if (!mailOptions.from) {
-            throw new Error('beforeSend hook must not remove the "from" property')
-          }
-          if (!mailOptions.to || (Array.isArray(mailOptions.to) && mailOptions.to.length === 0)) {
-            throw new Error('beforeSend hook must not remove or empty the "to" property')
-          }
-          if (!mailOptions.subject) {
-            throw new Error('beforeSend hook must not remove the "subject" property')
-          }
-          if (!mailOptions.html && !mailOptions.text) {
-            throw new Error('beforeSend hook must not remove both "html" and "text" properties')
-          }
-        } catch (error) {
-          console.error('Error in beforeSend hook:', error)
-          throw new Error(`beforeSend hook failed: ${error instanceof Error ? error.message : 'Unknown error'}`)
-        }
-      }
-
-      // Send email using Payload's email adapter
-      await this.payload.email.sendEmail(mailOptions)
-
-      await this.payload.update({
-        collection: this.emailsCollection as CollectionSlug,
-        id: emailId,
-        data: {
-          status: 'sent',
-          sentAt: new Date().toISOString(),
-          error: null,
-        },
-      })
-
-    } catch (error) {
-      const attempts = await this.incrementAttempts(emailId)
-      const maxAttempts = this.config.retryAttempts || 3
-
-      await this.payload.update({
-        collection: this.emailsCollection as CollectionSlug,
-        id: emailId,
-        data: {
-          status: attempts >= maxAttempts ? 'failed' : 'pending',
-          error: error instanceof Error ? error.message : 'Unknown error',
-          lastAttemptAt: new Date().toISOString(),
-        },
-      })
-
-      if (attempts >= maxAttempts) {
-        console.error(`Email ${emailId} failed permanently after ${attempts} attempts:`, error)
-      }
+      console.error(`Template with slug '${templateSlug}' not found:`, error)
+      return null
     }
   }
 
   private async incrementAttempts(emailId: string): Promise<number> {
     const email = await this.payload.findByID({
-      collection: this.emailsCollection as CollectionSlug,
       id: emailId,
+      collection: this.emailsCollection,
     })
 
     const newAttempts = ((email as any).attempts || 0) + 1
 
     await this.payload.update({
-      collection: this.emailsCollection as CollectionSlug,
       id: emailId,
+      collection: this.emailsCollection,
       data: {
         attempts: newAttempts,
       },
@@ -353,23 +151,20 @@ export class MailingService implements IMailingService {
     return newAttempts
   }
 
-  private async getTemplateBySlug(templateSlug: string): Promise<BaseEmailTemplateDocument | null> {
-    try {
-      const { docs } = await this.payload.find({
-        collection: this.templatesCollection as any,
-        where: {
-          slug: {
-            equals: templateSlug,
-          },
-        },
-        limit: 1,
-      })
-
-      return docs.length > 0 ? docs[0] as BaseEmailTemplateDocument : null
-    } catch (error) {
-      console.error(`Template with slug '${templateSlug}' not found:`, error)
-      return null
+  private async renderEmailTemplate(template: BaseEmailTemplateDocument, variables: Record<string, any> = {}): Promise<{ html: string; text: string }> {
+    if (!template.content) {
+      return { html: '', text: '' }
     }
+
+    // Serialize richtext to HTML and text
+    let html = serializeRichTextToHTML(template.content)
+    let text = serializeRichTextToText(template.content)
+
+    // Apply template variables to the rendered content
+    html = await this.renderTemplateString(html, variables)
+    text = await this.renderTemplateString(text, variables)
+
+    return { html, text }
   }
 
   private async renderTemplateString(template: string, variables: Record<string, any>): Promise<string> {
@@ -413,7 +208,7 @@ export class MailingService implements IMailingService {
     return this.simpleVariableReplacement(template, variables)
   }
 
-  private async renderWithMustache(template: string, variables: Record<string, any>): Promise<string | null> {
+  private async renderWithMustache(template: string, variables: Record<string, any>): Promise<null | string> {
     try {
       const mustacheModule = await import('mustache')
       const Mustache = mustacheModule.default || mustacheModule
@@ -423,6 +218,14 @@ export class MailingService implements IMailingService {
     }
   }
 
+  /**
+   * Sanitizes a display name for use in email headers to prevent header injection
+   * Uses the centralized sanitization utility with quote escaping for headers
+   */
+  private sanitizeDisplayName(name: string): string {
+    return sanitizeDisplayName(name, true) // escapeQuotes = true for email headers
+  }
+
   private simpleVariableReplacement(template: string, variables: Record<string, any>): string {
     return template.replace(/\{\{(\w+)\}\}/g, (match, key) => {
       const value = variables[key]
@@ -430,20 +233,221 @@ export class MailingService implements IMailingService {
     })
   }
 
-  private async renderEmailTemplate(template: BaseEmailTemplateDocument, variables: Record<string, any> = {}): Promise<{ html: string; text: string }> {
-    if (!template.content) {
-      return { html: '', text: '' }
+  async processEmailItem(emailId: string): Promise<void> {
+    try {
+      await this.payload.update({
+        id: emailId,
+        collection: this.emailsCollection,
+        data: {
+          lastAttemptAt: new Date().toISOString(),
+          status: 'processing',
+        },
+      })
+
+      const email = await this.payload.findByID({
+        id: emailId,
+        collection: this.emailsCollection,
+        depth: 1,
+      }) as BaseEmailDocument
+
+      // Combine from and fromName for nodemailer using proper sanitization
+      let fromField: string
+      if (email.from) {
+        fromField = this.formatEmailAddress(email.from, email.fromName)
+      } else {
+        fromField = this.getDefaultFrom()
+      }
+
+      let mailOptions: SendEmailOptions = {
+        bcc: email.bcc || undefined,
+        cc: email.cc || undefined,
+        from: fromField,
+        html: email.html,
+        replyTo: email.replyTo || undefined,
+        subject: email.subject,
+        text: email.text || undefined,
+        to: email.to,
+      }
+
+      if (!mailOptions.from) {
+        throw new Error('Email from field is required')
+      }
+      if (!mailOptions.to || (Array.isArray(mailOptions.to) && mailOptions.to.length === 0)) {
+        throw new Error('Email to field is required')
+      }
+      if (!mailOptions.subject) {
+        throw new Error('Email subject is required')
+      }
+      if (!mailOptions.html && !mailOptions.text) {
+        throw new Error('Email content is required')
+      }
+
+      // Call beforeSend hook if configured
+      if (this.config.beforeSend) {
+        try {
+          mailOptions = await this.config.beforeSend(mailOptions, email)
+
+          // Validate required properties remain intact after hook execution
+          if (!mailOptions.from) {
+            throw new Error('beforeSend hook must not remove the "from" property')
+          }
+          if (!mailOptions.to || (Array.isArray(mailOptions.to) && mailOptions.to.length === 0)) {
+            throw new Error('beforeSend hook must not remove or empty the "to" property')
+          }
+          if (!mailOptions.subject) {
+            throw new Error('beforeSend hook must not remove the "subject" property')
+          }
+          if (!mailOptions.html && !mailOptions.text) {
+            throw new Error('beforeSend hook must not remove both "html" and "text" properties')
+          }
+        } catch (error) {
+          console.error('Error in beforeSend hook:', error)
+          throw new Error(`beforeSend hook failed: ${error instanceof Error ? error.message : 'Unknown error'}`)
+        }
+      }
+
+      // Send email using Payload's email adapter
+      await this.payload.email.sendEmail(mailOptions)
+
+      await this.payload.update({
+        id: emailId,
+        collection: this.emailsCollection,
+        data: {
+          error: null,
+          sentAt: new Date().toISOString(),
+          status: 'sent',
+        },
+      })
+
+    } catch (error) {
+      const attempts = await this.incrementAttempts(emailId)
+      const maxAttempts = this.config.retryAttempts || 3
+
+      await this.payload.update({
+        id: emailId,
+        collection: this.emailsCollection,
+        data: {
+          error: error instanceof Error ? error.message : 'Unknown error',
+          lastAttemptAt: new Date().toISOString(),
+          status: attempts >= maxAttempts ? 'failed' : 'pending',
+        },
+      })
+
+      if (attempts >= maxAttempts) {
+        console.error(`Email ${emailId} failed permanently after ${attempts} attempts:`, error)
+      }
+    }
+  }
+
+  async processEmails(): Promise<void> {
+    this.ensureInitialized()
+    const currentTime = new Date().toISOString()
+
+    const { docs: pendingEmails } = await this.payload.find({
+      collection: this.emailsCollection,
+      limit: 50,
+      sort: 'priority,-createdAt',
+      where: {
+        and: [
+          {
+            status: {
+              equals: 'pending',
+            },
+          },
+          {
+            or: [
+              {
+                scheduledAt: {
+                  exists: false,
+                },
+              },
+              {
+                scheduledAt: {
+                  less_than_equal: currentTime,
+                },
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    for (const email of pendingEmails) {
+      await this.processEmailItem(String(email.id))
+    }
+  }
+
+  async renderTemplate(templateSlug: string, variables: TemplateVariables): Promise<{ html: string; subject: string; text: string }> {
+    this.ensureInitialized()
+    const template = await this.getTemplateBySlug(templateSlug)
+
+    if (!template) {
+      throw new Error(`Email template not found: ${templateSlug}`)
     }
 
-    // Serialize richtext to HTML and text
-    let html = serializeRichTextToHTML(template.content)
-    let text = serializeRichTextToText(template.content)
+    return this.renderTemplateDocument(template, variables)
+  }
 
-    // Apply template variables to the rendered content
-    html = await this.renderTemplateString(html, variables)
-    text = await this.renderTemplateString(text, variables)
+  /**
+   * Render a template document (for when you already have the template loaded)
+   * This avoids duplicate template lookups
+   * @internal
+   */
+  async renderTemplateDocument(template: BaseEmailTemplateDocument, variables: TemplateVariables): Promise<{ html: string; subject: string; text: string }> {
+    this.ensureInitialized()
 
-    return { html, text }
+    const emailContent = await this.renderEmailTemplate(template, variables)
+    const subject = await this.renderTemplateString(template.subject || '', variables)
+
+    return {
+      html: emailContent.html,
+      subject,
+      text: emailContent.text
+    }
+  }
+
+  async retryFailedEmails(): Promise<void> {
+    this.ensureInitialized()
+    const maxAttempts = this.config.retryAttempts || 3
+    const retryDelay = this.config.retryDelay || 300000 // 5 minutes
+    const retryTime = new Date(Date.now() - retryDelay).toISOString()
+
+    const { docs: failedEmails } = await this.payload.find({
+      collection: this.emailsCollection,
+      limit: 20,
+      where: {
+        and: [
+          {
+            status: {
+              equals: 'failed',
+            },
+          },
+          {
+            attempts: {
+              less_than: maxAttempts,
+            },
+          },
+          {
+            or: [
+              {
+                lastAttemptAt: {
+                  exists: false,
+                },
+              },
+              {
+                lastAttemptAt: {
+                  less_than: retryTime,
+                },
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    for (const email of failedEmails) {
+      await this.processEmailItem(String(email.id))
+    }
   }
 
 }

--- a/src/tasks/schedule-email.ts
+++ b/src/tasks/schedule-email.ts
@@ -1,40 +1,41 @@
 import type { TaskConfig, TaskHandler } from 'payload'
+
 import { sendEmail } from '../sendEmail.js'
 
 export interface ScheduleEmailInput {
-  to: string | string[]
+  bcc?: string | string[]
+  cc?: string | string[]
   from?: string
   fromName?: string
+  html?: string
+  priority?: 'critical' | 'high' | 'low' | 'normal'
+  processImmediately?: boolean
+  replyTo?: string
+  scheduledAt?: string
   subject?: string
   templateSlug?: string
   templateVariables?: Record<string, unknown>
-  html?: string
   text?: string
-  cc?: string | string[]
-  bcc?: string | string[]
-  replyTo?: string
-  scheduledAt?: string
-  priority?: 'low' | 'normal' | 'high' | 'critical'
-  processImmediately?: boolean
+  to: string | string[]
 }
 
 export interface ScheduleEmailOutput {
-  emailId: string | number
-  status: string
+  emailId: number | string
   scheduledAt?: string
+  status: string
 }
 
 // Map string priority to numeric value
 const priorityMap: Record<string, number> = {
+  critical: 4,
+  high: 3,
   low: 1,
   normal: 2,
-  high: 3,
-  critical: 4,
 }
 
 // Ensure value is an array of strings
 const ensureStringArray = (value: string | string[] | undefined): string[] | undefined => {
-  if (!value) return undefined
+  if (!value) {return undefined}
   return Array.isArray(value) ? value : [value]
 }
 
@@ -71,17 +72,17 @@ const scheduleEmailHandler: TaskHandler<'schedule-email'> = async ({ input, req 
     const priorityValue = typedInput.priority ? priorityMap[typedInput.priority] : 2
 
     const emailOptions: Parameters<typeof sendEmail>[1] = {
-      processImmediately: typedInput.processImmediately ?? false,
       data: {
-        to: toArray,
+        bcc: bccArray,
+        cc: ccArray,
         from: typedInput.from,
         fromName: typedInput.fromName,
-        cc: ccArray,
-        bcc: bccArray,
-        replyTo: typedInput.replyTo,
         priority: priorityValue,
+        replyTo: typedInput.replyTo,
         scheduledAt: typedInput.scheduledAt,
+        to: toArray,
       },
+      processImmediately: typedInput.processImmediately ?? false,
     }
 
     // Use template if provided
@@ -94,8 +95,8 @@ const scheduleEmailHandler: TaskHandler<'schedule-email'> = async ({ input, req 
       // Use direct content
       emailOptions.data = {
         ...emailOptions.data,
-        subject: typedInput.subject,
         html: typedInput.html,
+        subject: typedInput.subject,
         text: typedInput.text,
       }
     }
@@ -105,8 +106,8 @@ const scheduleEmailHandler: TaskHandler<'schedule-email'> = async ({ input, req 
     return {
       output: {
         emailId: String(email.id),
-        status: (email as { status?: string }).status || 'pending',
         scheduledAt: typedInput.scheduledAt,
+        status: (email as { status?: string }).status || 'pending',
       },
     }
   } catch (error) {
@@ -162,17 +163,16 @@ const scheduleEmailHandler: TaskHandler<'schedule-email'> = async ({ input, req 
  */
 export const ScheduleEmailTask = {
   slug: 'schedule-email',
-  label: 'Schedule Email',
   handler: scheduleEmailHandler,
   inputSchema: [
     {
       name: 'to',
       type: 'text',
-      required: true,
       admin: {
         description:
           'Recipient email address(es). Use JSONata for dynamic values (e.g., "trigger.doc.customer.email")',
       },
+      required: true,
     },
     {
       name: 'templateSlug',
@@ -254,26 +254,27 @@ export const ScheduleEmailTask = {
     {
       name: 'priority',
       type: 'select',
+      admin: {
+        description: 'Email priority level',
+      },
+      defaultValue: 'normal',
       options: [
         { label: 'Low', value: 'low' },
         { label: 'Normal', value: 'normal' },
         { label: 'High', value: 'high' },
         { label: 'Critical', value: 'critical' },
       ],
-      defaultValue: 'normal',
-      admin: {
-        description: 'Email priority level',
-      },
     },
     {
       name: 'processImmediately',
       type: 'checkbox',
-      defaultValue: false,
       admin: {
         description: 'Process and send the email immediately instead of queuing',
       },
+      defaultValue: false,
     },
   ],
+  label: 'Schedule Email',
   outputSchema: [
     {
       name: 'emailId',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,104 +1,103 @@
-import {Payload, SendEmailOptions} from 'payload'
-import type { CollectionConfig, RichTextField } from 'payload'
+import type { CollectionConfig, Payload,RichTextField, SendEmailOptions } from 'payload'
 
 // Payload ID type (string or number)
-export type PayloadID = string | number
+export type PayloadID = number | string
 
 // Payload relation type - can be populated (object with id) or unpopulated (just the ID)
-export type PayloadRelation<T extends { id: PayloadID }> = T | PayloadID
+export type PayloadRelation<T extends { id: PayloadID }> = PayloadID | T
 
 // JSON value type that matches Payload's JSON field type
-export type JSONValue = string | number | boolean | { [k: string]: unknown } | unknown[] | null | undefined
+export type JSONValue = { [k: string]: unknown } | boolean | null | number | string | undefined | unknown[]
 
 // Generic base interfaces that work with any ID type and null values
 export interface BaseEmailDocument {
-  id: string | number
-  template?: any
-  templateSlug?: string | null
-  to: string[]
-  cc?: string[] | null
-  bcc?: string[] | null
-  from?: string | null
-  fromName?: string | null
-  replyTo?: string | null
-  subject: string
+  attempts?: null | number
+  bcc?: null | string[]
+  cc?: null | string[]
+  createdAt?: Date | null | string
+  error?: null | string
+  from?: null | string
+  fromName?: null | string
   html: string
-  text?: string | null
+  id: number | string
+  lastAttemptAt?: Date | null | string
+  priority?: null | number
+  replyTo?: null | string
+  scheduledAt?: Date | null | string
+  sentAt?: Date | null | string
+  status?: 'failed' | 'pending' | 'processing' | 'sent' | null
+  subject: string
+  template?: any
+  templateSlug?: null | string
+  text?: null | string
+  to: string[]
+  updatedAt?: Date | null | string
   variables?: JSONValue
-  scheduledAt?: string | Date | null
-  sentAt?: string | Date | null
-  status?: 'pending' | 'processing' | 'sent' | 'failed' | null
-  attempts?: number | null
-  lastAttemptAt?: string | Date | null
-  error?: string | null
-  priority?: number | null
-  createdAt?: string | Date | null
-  updatedAt?: string | Date | null
 }
 
 export interface BaseEmailTemplateDocument {
-  id: string | number
+  content?: any
+  createdAt?: Date | null | string
+  id: number | string
   name: string
   slug: string
-  subject?: string | null
-  content?: any
-  createdAt?: string | Date | null
-  updatedAt?: string | Date | null
+  subject?: null | string
+  updatedAt?: Date | null | string
 }
 
-export type TemplateRendererHook = (template: string, variables: Record<string, any>) => string | Promise<string>
+export type TemplateRendererHook = (template: string, variables: Record<string, any>) => Promise<string> | string
 
 export type TemplateEngine = 'liquidjs' | 'mustache' | 'simple'
 
-export type BeforeSendHook = (options: SendEmailOptions, email: BaseEmailDocument) => SendEmailOptions | Promise<SendEmailOptions>
+export type BeforeSendHook = (options: SendEmailOptions, email: BaseEmailDocument) => Promise<SendEmailOptions> | SendEmailOptions
 
 export interface JobPollingConfig {
-  maxAttempts?: number        // Maximum number of polling attempts (default: 5)
   initialDelay?: number       // Initial delay in milliseconds (default: 25)
-  maxTotalTime?: number       // Maximum total polling time in milliseconds (default: 3000)
+  maxAttempts?: number        // Maximum number of polling attempts (default: 5)
   maxBackoffDelay?: number    // Maximum delay between attempts in milliseconds (default: 400)
+  maxTotalTime?: number       // Maximum total polling time in milliseconds (default: 3000)
 }
 
 export interface MailingPluginConfig {
+  beforeSend?: BeforeSendHook
   collections?: {
-    templates?: string | Partial<CollectionConfig>
-    emails?: string | Partial<CollectionConfig>
+    emails?: Partial<CollectionConfig> | string
+    templates?: Partial<CollectionConfig> | string
   }
   defaultFrom?: string
   defaultFromName?: string
+  initOrder?: 'after' | 'before'
+  jobPolling?: JobPollingConfig
   queue?: string
   retryAttempts?: number
   retryDelay?: number
-  templateRenderer?: TemplateRendererHook
-  templateEngine?: TemplateEngine
   richTextEditor?: RichTextField['editor']
-  beforeSend?: BeforeSendHook
-  initOrder?: 'before' | 'after'
-  jobPolling?: JobPollingConfig
+  templateEngine?: TemplateEngine
+  templateRenderer?: TemplateRendererHook
 }
 
 export interface QueuedEmail {
-  id: string
-  template?: string | null
-  to: string[]
-  cc?: string[] | null
-  bcc?: string[] | null
-  from?: string | null
-  fromName?: string | null
-  replyTo?: string | null
-  subject: string
-  html: string
-  text?: string | null
-  variables?: JSONValue
-  scheduledAt?: string | Date | null
-  sentAt?: string | Date | null
-  status: 'pending' | 'processing' | 'sent' | 'failed'
   attempts: number
-  lastAttemptAt?: string | Date | null
-  error?: string | null
-  priority?: number | null
+  bcc?: null | string[]
+  cc?: null | string[]
   createdAt: string
+  error?: null | string
+  from?: null | string
+  fromName?: null | string
+  html: string
+  id: string
+  lastAttemptAt?: Date | null | string
+  priority?: null | number
+  replyTo?: null | string
+  scheduledAt?: Date | null | string
+  sentAt?: Date | null | string
+  status: 'failed' | 'pending' | 'processing' | 'sent'
+  subject: string
+  template?: null | string
+  text?: null | string
+  to: string[]
   updatedAt: string
+  variables?: JSONValue
 }
 
 // Simple helper type for template variables
@@ -107,14 +106,14 @@ export interface TemplateVariables {
 }
 
 export interface MailingService {
-  processEmails(): Promise<void>
   processEmailItem(emailId: string): Promise<void>
+  processEmails(): Promise<void>
+  renderTemplate(templateSlug: string, variables: TemplateVariables): Promise<{ html: string; subject: string; text: string }>
   retryFailedEmails(): Promise<void>
-  renderTemplate(templateSlug: string, variables: TemplateVariables): Promise<{ html: string; text: string; subject: string }>
 }
 
 export interface MailingContext {
-  payload: Payload
   config: MailingPluginConfig
+  payload: Payload
   service: MailingService
 }

--- a/src/utils/emailProcessor.ts
+++ b/src/utils/emailProcessor.ts
@@ -1,4 +1,5 @@
 import type { Payload } from 'payload'
+
 import { createContextLogger } from './logger.js'
 
 /**

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,12 +1,13 @@
-import { Payload } from 'payload'
-import { TemplateVariables, PayloadID, PayloadRelation } from '../types/index.js'
+import type { Payload } from 'payload'
+
+import type { PayloadID, PayloadRelation, TemplateVariables } from '../types/index.js'
 
 /**
  * Parse and validate email addresses
  * @internal
  */
-export const parseAndValidateEmails = (emails: string | string[] | null | undefined): string[] | undefined => {
-  if (!emails || emails === null) return undefined
+export const parseAndValidateEmails = (emails: null | string | string[] | undefined): string[] | undefined => {
+  if (!emails || emails === null) {return undefined}
 
   let emailList: string[]
   if (Array.isArray(emails)) {
@@ -16,16 +17,16 @@ export const parseAndValidateEmails = (emails: string | string[] | null | undefi
   }
 
   // RFC 5322 compliant email validation
-  const emailRegex = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/
+  const emailRegex = /^[\w.!#$%&'*+/=?^`{|}~-]+@[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$/i
   const invalidEmails = emailList.filter(email => {
     // Check basic format
-    if (!emailRegex.test(email)) return true
+    if (!emailRegex.test(email)) {return true}
     // Check for common invalid patterns
-    if (email.includes('..') || email.startsWith('.') || email.endsWith('.')) return true
-    if (email.includes('@.') || email.includes('.@')) return true
+    if (email.includes('..') || email.startsWith('.') || email.endsWith('.')) {return true}
+    if (email.includes('@.') || email.includes('.@')) {return true}
     // Check domain has at least one dot
     const parts = email.split('@')
-    if (parts.length !== 2 || !parts[1].includes('.')) return true
+    if (parts.length !== 2 || !parts[1].includes('.')) {return true}
     return false
   })
 
@@ -44,13 +45,15 @@ export const parseAndValidateEmails = (emails: string | string[] | null | undefi
  * @returns Sanitized display name
  */
 export const sanitizeDisplayName = (displayName: string, escapeQuotes = false): string => {
-  if (!displayName) return displayName
+  if (!displayName) {return displayName}
 
   let sanitized = displayName
     .trim()
     // Remove/replace newlines and carriage returns to prevent header injection
     .replace(/[\r\n]/g, ' ')
-    // Remove control characters (except space and printable characters)
+    // Remove control characters (except space and printable characters).
+    // The control-character ranges are intentional here.
+    // eslint-disable-next-line no-control-regex
     .replace(/[\x00-\x1F\x7F-\x9F]/g, '')
 
   // Escape quotes if needed (for email headers)
@@ -67,8 +70,8 @@ export const sanitizeDisplayName = (displayName: string, escapeQuotes = false): 
  * @param fromName - The fromName to sanitize
  * @returns Sanitized fromName or undefined if empty after sanitization
  */
-export const sanitizeFromName = (fromName: string | null | undefined): string | undefined => {
-  if (!fromName) return undefined
+export const sanitizeFromName = (fromName: null | string | undefined): string | undefined => {
+  if (!fromName) {return undefined}
 
   const sanitized = sanitizeDisplayName(fromName, false)
   return sanitized.length > 0 ? sanitized : undefined
@@ -78,7 +81,7 @@ export const sanitizeFromName = (fromName: string | null | undefined): string | 
  * Type guard to check if a Payload relation is populated (object) or unpopulated (ID)
  */
 export const isPopulated = <T extends { id: PayloadID }>(
-  value: PayloadRelation<T> | null | undefined
+  value: null | PayloadRelation<T> | undefined
 ): value is T => {
   return value !== null && value !== undefined && typeof value === 'object' && 'id' in value
 }
@@ -88,9 +91,9 @@ export const isPopulated = <T extends { id: PayloadID }>(
  * Handles both populated (object with id) and unpopulated (string/number) values
  */
 export const resolveID = <T extends { id: PayloadID }>(
-  value: PayloadRelation<T> | null | undefined
+  value: null | PayloadRelation<T> | undefined
 ): PayloadID | undefined => {
-  if (value === null || value === undefined) return undefined
+  if (value === null || value === undefined) {return undefined}
 
   if (typeof value === 'string' || typeof value === 'number') {
     return value
@@ -108,9 +111,9 @@ export const resolveID = <T extends { id: PayloadID }>(
  * Handles mixed arrays of populated and unpopulated values
  */
 export const resolveIDs = <T extends { id: PayloadID }>(
-  values: (PayloadRelation<T> | null | undefined)[] | null | undefined
+  values: (null | PayloadRelation<T> | undefined)[] | null | undefined
 ): PayloadID[] => {
-  if (!values || !Array.isArray(values)) return []
+  if (!values || !Array.isArray(values)) {return []}
 
   return values
     .map(value => resolveID(value))
@@ -125,7 +128,7 @@ export const getMailing = (payload: Payload) => {
   return mailing
 }
 
-export const renderTemplate = async (payload: Payload, templateSlug: string, variables: TemplateVariables): Promise<{ html: string; text: string; subject: string }> => {
+export const renderTemplate = (payload: Payload, templateSlug: string, variables: TemplateVariables): Promise<{ html: string; subject: string; text: string }> => {
   const mailing = getMailing(payload)
   return mailing.service.renderTemplate(templateSlug, variables)
 }
@@ -139,7 +142,7 @@ export const renderTemplateWithId = async (
   payload: Payload,
   templateSlug: string,
   variables: TemplateVariables
-): Promise<{ html: string; text: string; subject: string; templateId: PayloadID }> => {
+): Promise<{ html: string; subject: string; templateId: PayloadID; text: string }> => {
   const mailing = getMailing(payload)
   const templatesCollection = mailing.config.collections?.templates || 'email-templates'
 
@@ -153,13 +156,13 @@ export const renderTemplateWithId = async (
 
   // Look up the template document once
   const { docs: templateDocs } = await payload.find({
-    collection: templatesCollection as any,
+    collection: templatesCollection,
+    limit: 1,
     where: {
       slug: {
         equals: templateSlug,
       },
     },
-    limit: 1,
   })
 
   if (!templateDocs || templateDocs.length === 0) {
@@ -177,12 +180,12 @@ export const renderTemplateWithId = async (
   }
 }
 
-export const processEmails = async (payload: Payload): Promise<void> => {
+export const processEmails = (payload: Payload): Promise<void> => {
   const mailing = getMailing(payload)
   return mailing.service.processEmails()
 }
 
-export const retryFailedEmails = async (payload: Payload): Promise<void> => {
+export const retryFailedEmails = (payload: Payload): Promise<void> => {
   const mailing = getMailing(payload)
   return mailing.service.retryFailedEmails()
 }

--- a/src/utils/jobPolling.ts
+++ b/src/utils/jobPolling.ts
@@ -1,31 +1,32 @@
-import { Payload } from 'payload'
-import { JobPollingConfig } from '../types/index.js'
+import type { Payload } from 'payload'
+
+import type { JobPollingConfig } from '../types/index.js'
 
 export interface PollForJobIdOptions {
-  payload: Payload
   collectionSlug: string
-  emailId: string | number
   config?: JobPollingConfig
+  emailId: number | string
   logger?: {
     debug: (message: string, ...args: any[]) => void
+    error: (message: string, ...args: any[]) => void
     info: (message: string, ...args: any[]) => void
     warn: (message: string, ...args: any[]) => void
-    error: (message: string, ...args: any[]) => void
   }
+  payload: Payload
 }
 
 export interface PollForJobIdResult {
-  jobId: string
   attempts: number
   elapsedTime: number
+  jobId: string
 }
 
 // Default job polling configuration values
 const DEFAULT_JOB_POLLING_CONFIG: Required<JobPollingConfig> = {
-  maxAttempts: 5,
   initialDelay: 25,
-  maxTotalTime: 3000,
+  maxAttempts: 5,
   maxBackoffDelay: 400,
+  maxTotalTime: 3000,
 }
 
 /**
@@ -42,7 +43,7 @@ const DEFAULT_JOB_POLLING_CONFIG: Required<JobPollingConfig> = {
  * @throws Error if job is not found within the configured limits
  */
 export const pollForJobId = async (options: PollForJobIdOptions): Promise<PollForJobIdResult> => {
-  const { payload, collectionSlug, emailId, logger } = options
+  const { collectionSlug, emailId, logger, payload } = options
 
   // Merge user config with defaults
   const config: Required<JobPollingConfig> = {
@@ -50,7 +51,7 @@ export const pollForJobId = async (options: PollForJobIdOptions): Promise<PollFo
     ...options.config,
   }
 
-  const { maxAttempts, initialDelay, maxTotalTime, maxBackoffDelay } = config
+  const { initialDelay, maxAttempts, maxBackoffDelay, maxTotalTime } = config
   const startTime = Date.now()
   let jobId: string | undefined
 
@@ -75,8 +76,8 @@ export const pollForJobId = async (options: PollForJobIdOptions): Promise<PollFo
 
     // Fetch the email document to check for associated jobs
     const emailWithJobs = await payload.findByID({
-      collection: collectionSlug,
       id: emailId,
+      collection: collectionSlug,
     })
 
     // Check if jobs array exists and has entries
@@ -85,9 +86,9 @@ export const pollForJobId = async (options: PollForJobIdOptions): Promise<PollFo
       jobId = typeof firstJob === 'string' ? firstJob : String(firstJob.id || firstJob)
 
       return {
-        jobId,
         attempts: attempt + 1,
         elapsedTime: Date.now() - startTime,
+        jobId,
       }
     }
 

--- a/src/utils/jobScheduler.ts
+++ b/src/utils/jobScheduler.ts
@@ -1,4 +1,5 @@
 import type { Payload } from 'payload'
+
 import { createContextLogger } from './logger.js'
 
 /**
@@ -6,10 +7,11 @@ import { createContextLogger } from './logger.js'
  */
 export async function findExistingJobs(
   payload: Payload,
-  emailId: string | number
+  emailId: number | string
 ): Promise<{ docs: any[], totalDocs: number }> {
   return await payload.find({
     collection: 'payload-jobs',
+    limit: 10,
     where: {
       'input.emailId': {
         equals: String(emailId),
@@ -18,7 +20,6 @@ export async function findExistingJobs(
         equals: 'process-email',
       },
     },
-    limit: 10,
   })
 }
 
@@ -34,12 +35,12 @@ export async function findExistingJobs(
  */
 export async function ensureEmailJob(
   payload: Payload,
-  emailId: string | number,
+  emailId: number | string,
   options?: {
-    scheduledAt?: string | Date
     queueName?: string
+    scheduledAt?: Date | string
   }
-): Promise<{ jobIds: (string | number)[], created: boolean }> {
+): Promise<{ created: boolean, jobIds: (number | string)[] }> {
   if (!payload.jobs) {
     throw new Error('PayloadCMS jobs not configured - cannot create email job')
   }
@@ -57,19 +58,19 @@ export async function ensureEmailJob(
   try {
     // Attempt to create job - rely on database constraints for duplicate prevention
     const job = await payload.jobs.queue({
-      queue: queueName,
-      task: 'process-email',
       input: {
         emailId: normalizedEmailId
       },
+      queue: queueName,
+      task: 'process-email',
       waitUntil: options?.scheduledAt ? new Date(options.scheduledAt) : undefined
     })
 
     logger.info(`Auto-scheduled processing job ${job.id} for email ${normalizedEmailId}`)
 
     return {
-      jobIds: [job.id],
-      created: true
+      created: true,
+      jobIds: [job.id]
     }
   } catch (createError) {
 
@@ -83,8 +84,8 @@ export async function ensureEmailJob(
       // Found existing jobs - return them (race condition handled successfully)
       logger.debug(`Using existing jobs for email ${normalizedEmailId}: ${existingJobs.docs.map(j => j.id).join(', ')}`)
       return {
-        jobIds: existingJobs.docs.map(job => job.id),
-        created: false
+        created: false,
+        jobIds: existingJobs.docs.map(job => job.id)
       }
     }
 
@@ -115,8 +116,8 @@ export async function ensureEmailJob(
  */
 export async function updateEmailJobRelationship(
   payload: Payload,
-  emailId: string | number,
-  jobIds: (string | number)[],
+  emailId: number | string,
+  jobIds: (number | string)[],
   collectionSlug: string = 'emails'
 ): Promise<void> {
   try {
@@ -125,8 +126,8 @@ export async function updateEmailJobRelationship(
 
     // Get current jobs to avoid overwriting
     const currentEmail = await payload.findByID({
-      collection: collectionSlug,
       id: normalizedEmailId,
+      collection: collectionSlug,
     })
 
     // Extract IDs from job objects or use the value directly if it's already an ID
@@ -137,8 +138,8 @@ export async function updateEmailJobRelationship(
     const allJobs = [...new Set([...currentJobs, ...normalizedJobIds])] // Deduplicate with normalized strings
 
     await payload.update({
-      collection: collectionSlug,
       id: normalizedEmailId,
+      collection: collectionSlug,
       data: {
         jobs: allJobs
       }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -24,9 +24,9 @@ export function getPluginLogger(payload: Payload) {
   if (!pluginLogger) {
     return {
       debug: (...args: any[]) => console.log('[MAILING DEBUG]', ...args),
+      error: (...args: any[]) => console.error('[MAILING ERROR]', ...args),
       info: (...args: any[]) => console.log('[MAILING INFO]', ...args),
       warn: (...args: any[]) => console.warn('[MAILING WARN]', ...args),
-      error: (...args: any[]) => console.error('[MAILING ERROR]', ...args),
     }
   }
 
@@ -41,8 +41,8 @@ export function createContextLogger(payload: Payload, context: string) {
 
   return {
     debug: (message: string, ...args: any[]) => logger.debug(`[${context}] ${message}`, ...args),
+    error: (message: string, ...args: any[]) => logger.error(`[${context}] ${message}`, ...args),
     info: (message: string, ...args: any[]) => logger.info(`[${context}] ${message}`, ...args),
     warn: (message: string, ...args: any[]) => logger.warn(`[${context}] ${message}`, ...args),
-    error: (message: string, ...args: any[]) => logger.error(`[${context}] ${message}`, ...args),
   }
 }

--- a/src/utils/richTextSerializer.ts
+++ b/src/utils/richTextSerializer.ts
@@ -6,14 +6,14 @@ interface SerializedEditorState {
 }
 
 interface SerializedLexicalNode {
-  type: string
   children?: SerializedLexicalNode[]
-  text?: string
   format?: number
-  tag?: string
-  listType?: 'number' | 'bullet'
-  url?: string
+  listType?: 'bullet' | 'number'
   newTab?: boolean
+  tag?: string
+  text?: string
+  type: string
+  url?: string
 }
 
 /**
@@ -43,65 +43,72 @@ function serializeNodesToHTML(nodes: SerializedLexicalNode[]): string {
 }
 
 function serializeNodeToHTML(node: SerializedLexicalNode): string {
-  if (!node) return ''
+  if (!node) {return ''}
 
   switch (node.type) {
-    case 'paragraph':
-      const children = node.children ? serializeNodesToHTML(node.children) : ''
-      return `<p>${children}</p>`
-
-    case 'heading':
+    case 'heading': {
       const headingChildren = node.children ? serializeNodesToHTML(node.children) : ''
       const tag = node.tag || 'h1'
       return `<${tag}>${headingChildren}</${tag}>`
+    }
 
-    case 'text':
+    case 'horizontalrule':
+      return '<hr>'
+
+    case 'linebreak':
+      return '<br>'
+
+    case 'link': {
+      const linkChildren = node.children ? serializeNodesToHTML(node.children) : ''
+      const url = node.url || '#'
+      const target = node.newTab ? ' target="_blank" rel="noopener noreferrer"' : ''
+      return `<a href="${url}"${target}>${linkChildren}</a>`
+    }
+
+    case 'list': {
+      const listChildren = node.children ? serializeNodesToHTML(node.children) : ''
+      const listTag = node.listType === 'number' ? 'ol' : 'ul'
+      return `<${listTag}>${listChildren}</${listTag}>`
+    }
+
+    case 'listitem': {
+      const listItemChildren = node.children ? serializeNodesToHTML(node.children) : ''
+      return `<li>${listItemChildren}</li>`
+    }
+
+    case 'paragraph': {
+      const children = node.children ? serializeNodesToHTML(node.children) : ''
+      return `<p>${children}</p>`
+    }
+
+    case 'quote': {
+      const quoteChildren = node.children ? serializeNodesToHTML(node.children) : ''
+      return `<blockquote>${quoteChildren}</blockquote>`
+    }
+
+    case 'text': {
       let text = node.text || ''
 
       // Apply text formatting using proper nesting order
       if (node.format) {
         const formatFlags = {
           bold: (node.format & 1) !== 0,
+          code: (node.format & 16) !== 0,
           italic: (node.format & 2) !== 0,
           strikethrough: (node.format & 4) !== 0,
           underline: (node.format & 8) !== 0,
-          code: (node.format & 16) !== 0,
         }
 
         // Apply formatting in proper nesting order: code > bold > italic > underline > strikethrough
-        if (formatFlags.code) text = `<code>${text}</code>`
-        if (formatFlags.bold) text = `<strong>${text}</strong>`
-        if (formatFlags.italic) text = `<em>${text}</em>`
-        if (formatFlags.underline) text = `<u>${text}</u>`
-        if (formatFlags.strikethrough) text = `<s>${text}</s>`
+        if (formatFlags.code) {text = `<code>${text}</code>`}
+        if (formatFlags.bold) {text = `<strong>${text}</strong>`}
+        if (formatFlags.italic) {text = `<em>${text}</em>`}
+        if (formatFlags.underline) {text = `<u>${text}</u>`}
+        if (formatFlags.strikethrough) {text = `<s>${text}</s>`}
       }
 
       return text
-
-    case 'linebreak':
-      return '<br>'
-
-    case 'list':
-      const listChildren = node.children ? serializeNodesToHTML(node.children) : ''
-      const listTag = node.listType === 'number' ? 'ol' : 'ul'
-      return `<${listTag}>${listChildren}</${listTag}>`
-
-    case 'listitem':
-      const listItemChildren = node.children ? serializeNodesToHTML(node.children) : ''
-      return `<li>${listItemChildren}</li>`
-
-    case 'quote':
-      const quoteChildren = node.children ? serializeNodesToHTML(node.children) : ''
-      return `<blockquote>${quoteChildren}</blockquote>`
-
-    case 'link':
-      const linkChildren = node.children ? serializeNodesToHTML(node.children) : ''
-      const url = node.url || '#'
-      const target = node.newTab ? ' target="_blank" rel="noopener noreferrer"' : ''
-      return `<a href="${url}"${target}>${linkChildren}</a>`
-
-    case 'horizontalrule':
-      return '<hr>'
+    }
 
     default:
       // Handle unknown nodes by processing children
@@ -117,42 +124,48 @@ function serializeNodesToText(nodes: SerializedLexicalNode[]): string {
 }
 
 function serializeNodeToText(node: SerializedLexicalNode): string {
-  if (!node) return ''
+  if (!node) {return ''}
 
   switch (node.type) {
-    case 'paragraph':
-      const children = node.children ? serializeNodesToText(node.children) : ''
-      return `${children}\n\n`
-
-    case 'heading':
+    case 'heading': {
       const headingChildren = node.children ? serializeNodesToText(node.children) : ''
       return `${headingChildren}\n\n`
+    }
 
-    case 'text':
-      return node.text || ''
+    case 'horizontalrule':
+      return '---\n\n'
 
     case 'linebreak':
       return '\n'
 
-    case 'list':
-      const listChildren = node.children ? serializeNodesToText(node.children) : ''
-      return `${listChildren}\n`
-
-    case 'listitem':
-      const listItemChildren = node.children ? serializeNodesToText(node.children) : ''
-      return `• ${listItemChildren}\n`
-
-    case 'quote':
-      const quoteChildren = node.children ? serializeNodesToText(node.children) : ''
-      return `> ${quoteChildren}\n\n`
-
-    case 'link':
+    case 'link': {
       const linkChildren = node.children ? serializeNodesToText(node.children) : ''
       const url = node.url || ''
       return `${linkChildren} (${url})`
+    }
 
-    case 'horizontalrule':
-      return '---\n\n'
+    case 'list': {
+      const listChildren = node.children ? serializeNodesToText(node.children) : ''
+      return `${listChildren}\n`
+    }
+
+    case 'listitem': {
+      const listItemChildren = node.children ? serializeNodesToText(node.children) : ''
+      return `• ${listItemChildren}\n`
+    }
+
+    case 'paragraph': {
+      const children = node.children ? serializeNodesToText(node.children) : ''
+      return `${children}\n\n`
+    }
+
+    case 'quote': {
+      const quoteChildren = node.children ? serializeNodesToText(node.children) : ''
+      return `> ${quoteChildren}\n\n`
+    }
+
+    case 'text':
+      return node.text || ''
 
     default:
       // Handle unknown nodes by processing children


### PR DESCRIPTION
## Why

The CI `Lint` step (`pnpm lint`) was failing because the repo had **no ESLint config at all** — ESLint 9 requires a flat `eslint.config.js`, and one was never committed even though `@payloadcms/eslint-config` is already a devDependency.

## What

- **`eslint.config.js`** — extends `rootEslintConfig` from `@payloadcms/eslint-config`, enables type-aware linting (`parserOptions.projectService` + `tsconfigRootDir`), and ignores `dist/`, `dev/`, and JS files.
- **`package.json`** — scope `lint` to `./src` (consistent with `lint:fix`) for deterministic runs.
- **`src/`** — ran `eslint --fix` (import / object-key / switch-case sorting per the Payload house style) and fixed the remaining errors manually:
  - `richTextSerializer.ts`: brace case blocks that declare locals (`no-case-declarations`).
  - `helpers.ts`: drop redundant `async` on three promise-returning wrappers (`require-await`); disable `no-control-regex` on the intentional control-char sanitization range.

## Result

`pnpm lint` → **0 errors** (exit 0). 65 warnings remain (`no-console`, `no-explicit-any`, unused vars) — these are non-blocking and overlap with the cleanup checklist in #78. `pnpm build` verified locally.

> Note: most of the diff is mechanical `--fix` reformatting, not logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)