### PR TITLE
fix: correct inverted email priority mapping (#70)

### DIFF
--- a/src/tasks/schedule-email.ts
+++ b/src/tasks/schedule-email.ts
@@ -25,12 +25,12 @@ export interface ScheduleEmailOutput {
   status: string
 }
 
-// Map string priority to numeric value
+// Map string priority to numeric value (1 = highest, 10 = lowest)
 const priorityMap: Record<string, number> = {
-  critical: 4,
+  critical: 1,
   high: 3,
-  low: 1,
-  normal: 2,
+  low: 7,
+  normal: 5,
 }
 
 // Ensure value is an array of strings
@@ -69,7 +69,7 @@ const scheduleEmailHandler: TaskHandler<'schedule-email'> = async ({ input, req 
     const toArray = ensureStringArray(typedInput.to)
     const ccArray = ensureStringArray(typedInput.cc)
     const bccArray = ensureStringArray(typedInput.bcc)
-    const priorityValue = typedInput.priority ? priorityMap[typedInput.priority] : 2
+    const priorityValue = typedInput.priority ? priorityMap[typedInput.priority] : 5
 
     const emailOptions: Parameters<typeof sendEmail>[1] = {
       data: {


### PR DESCRIPTION
## Summary

The `schedule-email` task mapped string priorities the wrong way around, so the most urgent mail was deprioritized.

The Emails collection documents `priority` as `1=highest, 10=lowest` and `MailingService.processEmails` sorts by `priority,-createdAt` ascending (priority 1 sent first). The previous `priorityMap` mapped `critical` to the highest number (4) and `low` to the lowest (1), inverting the intended ordering — `critical` mail was effectively sent after `low`.

## What changed

`src/tasks/schedule-email.ts`:
- Inverted `priorityMap` to align with `1=highest, 10=lowest`:
  `critical: 1, high: 3, normal: 5, low: 7`
- Changed the default fallback for an unspecified priority from `2` to `5` (mid-range / normal), consistent with the collection's `defaultValue`.
- Fixed the inline comment to state `1 = highest, 10 = lowest`.

Typecheck (`tsc --noEmit --project ./tsconfig.build.json`) passes.

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)