### PR TITLE
fix: use configured templates slug in Emails beforeChange hook (#75)

### DIFF
--- a/src/collections/Emails.ts
+++ b/src/collections/Emails.ts
@@ -1,6 +1,6 @@
 import type { CollectionConfig } from 'payload'
 
-import { resolveID } from '../utils/helpers.js'
+import { getMailing, resolveID } from '../utils/helpers.js'
 import { ensureEmailJob } from '../utils/jobScheduler.js'
 import { createContextLogger } from '../utils/logger.js'
 
@@ -222,9 +222,18 @@ const Emails: CollectionConfig = {
         // Auto-populate templateSlug from template relationship
         if (data.template) {
           try {
+            // Resolve the configured templates collection slug at runtime, since it
+            // is customizable via the plugin's `collections.templates` option.
+            // Fall back to the default slug if the mailing context is unavailable.
+            let templatesCollection = 'email-templates'
+            try {
+              templatesCollection = getMailing(req.payload).collections.templates
+            } catch {
+              // Mailing context not initialized; keep the default slug.
+            }
             const template = await req.payload.findByID({
               id: typeof data.template === 'string' ? data.template : data.template.id,
-              collection: 'email-templates',
+              collection: templatesCollection,
             })
             data.templateSlug = template.slug
           } catch (error) {


### PR DESCRIPTION
## Summary

The Emails `beforeChange` hook hardcoded `collection: 'email-templates'` in its `findByID` lookup used to auto-populate `templateSlug`. When a user configured a custom templates collection slug via `collections.templates`, the lookup failed and the catch block silently cleared `data.templateSlug`.

## What changed

- `src/collections/Emails.ts`: the `beforeChange` hook now resolves the configured templates collection slug at runtime via the established `getMailing(req.payload).collections.templates` pattern, falling back to `'email-templates'` if the mailing context isn't available (so default behavior is unchanged).
- Reused the existing `getMailing` helper from `src/utils/helpers.ts` for consistency rather than adding a new cast.
- The existing catch-block behavior (clearing `templateSlug` on lookup failure) is preserved.

## Verification

- `tsc --project ./tsconfig.build.json --noEmit` passes with no errors.
- ESLint on the changed file reports only pre-existing warnings (none introduced by this change).

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)