### PR TITLE
docs: correct template syntax to Liquid filter form (#77)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ mailingPlugin({
 Use `{{}}` to insert data in templates:
 
 - `{{user.name}}` - User data from variables
-- `{{formatDate createdAt "short"}}` - Built-in date formatting
-- `{{formatCurrency amount "USD"}}` - Currency formatting
+- `{{ createdAt | formatDate: "short" }}` - Built-in date formatting
+- `{{ amount | formatCurrency: "USD" }}` - Currency formatting
 
 ### Template Structure
 
@@ -179,7 +179,7 @@ Welcome to {{siteName}}!
 
 ---
 **Account Details:**
-- Created: {{formatDate user.createdAt "long"}}
+- Created: {{ user.createdAt | formatDate: "long" }}
 - Email: {{user.email}}
 - Plan: {{user.plan | capitalize}}
 

--- a/src/collections/EmailTemplates.ts
+++ b/src/collections/EmailTemplates.ts
@@ -41,7 +41,7 @@ export const createEmailTemplatesCollection = (editor?: RichTextField['editor'])
       name: 'subject',
       type: 'text',
       admin: {
-        description: 'Email subject line. You can use Handlebars variables like {{firstName}} or {{siteName}}.',
+        description: 'Email subject line. You can use Liquid variables like {{ firstName }} or {{ siteName }}.',
       },
       required: true,
     },
@@ -49,7 +49,7 @@ export const createEmailTemplatesCollection = (editor?: RichTextField['editor'])
       name: 'content',
       type: 'richText',
       admin: {
-        description: 'Email content with rich text formatting. Supports Handlebars variables like {{firstName}} and helpers like {{formatDate createdAt "long"}}. Content is converted to HTML and plain text automatically.',
+        description: 'Email content with rich text formatting. Supports Liquid variables like {{ firstName }} and filters like {{ createdAt | formatDate: "long" }}. Content is converted to HTML and plain text automatically. Set templateEngine to "mustache" or "simple" in the plugin config for alternative syntaxes.',
       },
       editor: editor || lexicalEditor({
         features: ({ defaultFeatures }) => [


### PR DESCRIPTION
## Summary

The EmailTemplates admin field descriptions and the README advertised Handlebars syntax/helpers, but the default template engine is LiquidJS. The documented helper call form `{{formatDate createdAt "long"}}` is invalid Liquid; the correct form is the filter pipe `{{ createdAt | formatDate: "long" }}`.

## What changed

- `src/collections/EmailTemplates.ts`:
  - `subject` description now references Liquid variables: `{{ firstName }}` / `{{ siteName }}`.
  - `content` description now uses the Liquid filter pipe form `{{ createdAt | formatDate: "long" }}` and notes that `templateEngine` can be set to `mustache` or `simple` for alternative syntaxes.
- `README.md` Templates section: changed the `formatDate` and `formatCurrency` examples from Handlebars call form to Liquid filter pipe form (`{{ createdAt | formatDate: "short" }}`, `{{ amount | formatCurrency: "USD" }}`), and fixed the body template example's `formatDate` usage.

Filter names and argument forms verified against the `registerFilter` registrations in `src/services/MailingService.ts`. The custom-renderer `handlebars.compile(...)` snippet (a legitimate bring-your-own-engine example) was intentionally left unchanged.

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)