### PR TITLE
fix: sync MailingContext type with runtime collections (#76)

### DIFF
--- a/src/sendEmail.ts
+++ b/src/sendEmail.ts
@@ -139,7 +139,7 @@ export const sendEmail = async <TEmail extends BaseEmailDocument = BaseEmailDocu
     // Poll for the job ID using configurable polling mechanism
     const { jobId } = await pollForJobId({
       collectionSlug,
-      config: mailingConfig.jobPolling,
+      config: mailingConfig.config.jobPolling,
       emailId: email.id,
       logger,
       payload,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -109,10 +109,15 @@ export interface MailingService {
   processEmailItem(emailId: string): Promise<void>
   processEmails(): Promise<void>
   renderTemplate(templateSlug: string, variables: TemplateVariables): Promise<{ html: string; subject: string; text: string }>
+  renderTemplateDocument(template: BaseEmailTemplateDocument, variables: TemplateVariables): Promise<{ html: string; subject: string; text: string }>
   retryFailedEmails(): Promise<void>
 }
 
 export interface MailingContext {
+  collections: {
+    emails: string
+    templates: string
+  }
   config: MailingPluginConfig
   payload: Payload
   service: MailingService

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,6 +1,6 @@
 import type { Payload } from 'payload'
 
-import type { PayloadID, PayloadRelation, TemplateVariables } from '../types/index.js'
+import type { BaseEmailTemplateDocument, MailingContext, PayloadID, PayloadRelation, TemplateVariables } from '../types/index.js'
 
 /**
  * Parse and validate email addresses
@@ -120,8 +120,8 @@ export const resolveIDs = <T extends { id: PayloadID }>(
     .filter((id): id is PayloadID => id !== undefined)
 }
 
-export const getMailing = (payload: Payload) => {
-  const mailing = (payload as any).mailing
+export const getMailing = (payload: Payload): MailingContext => {
+  const mailing = (payload as any).mailing as MailingContext | undefined
   if (!mailing) {
     throw new Error('Mailing plugin not initialized. Make sure you have added the mailingPlugin to your Payload config.')
   }
@@ -144,7 +144,7 @@ export const renderTemplateWithId = async (
   variables: TemplateVariables
 ): Promise<{ html: string; subject: string; templateId: PayloadID; text: string }> => {
   const mailing = getMailing(payload)
-  const templatesCollection = mailing.config.collections?.templates || 'email-templates'
+  const templatesCollection = mailing.collections.templates || 'email-templates'
 
   // Runtime validation: Ensure the collection exists in Payload
   if (!payload.collections[templatesCollection]) {
@@ -172,7 +172,7 @@ export const renderTemplateWithId = async (
   const templateDoc = templateDocs[0]
 
   // Render using the document directly to avoid duplicate lookup
-  const rendered = await mailing.service.renderTemplateDocument(templateDoc, variables)
+  const rendered = await mailing.service.renderTemplateDocument(templateDoc as unknown as BaseEmailTemplateDocument, variables)
 
   return {
     ...rendered,


### PR DESCRIPTION
## Summary

`MailingContext` in `src/types/index.ts` was out of sync with the object the plugin assigns to `payload.mailing` at runtime (`src/plugin.ts`): the runtime object includes a `collections` property, but the interface omitted it. Because `getMailing` returned `any`, consumers reading `mailing.collections.emails` compiled regardless. This PR makes the type match reality and tightens `getMailing`'s return type.

## What changed

- **`src/types/index.ts`**
  - Added `collections: { templates: string; emails: string }` to `MailingContext`, matching the runtime shape in `src/plugin.ts` (lines 101-109).
  - Added the existing `renderTemplateDocument(...)` method to the `MailingService` interface (it existed on the class but was missing from the interface).
- **`src/utils/helpers.ts`**
  - Typed `getMailing`'s return as `MailingContext` instead of `any`.
- **`src/sendEmail.ts`** (surfaced by the stricter type)
  - Fixed `mailingConfig.jobPolling` → `mailingConfig.config.jobPolling`. The runtime object has no top-level `jobPolling`; it lives at `config.jobPolling`, so user-configured polling settings were previously silently ignored.
- **`src/utils/helpers.ts`** (surfaced by the stricter type)
  - `renderTemplateWithId` now resolves the templates collection from the already-resolved slug `mailing.collections.templates` instead of the raw user config `mailing.config.collections?.templates`, which may be a collection object rather than a string.
  - Cast the `payload.find` result to `BaseEmailTemplateDocument` when passing it to `renderTemplateDocument`.

## Typecheck

`npx tsc --project ./tsconfig.build.json --noEmit` passes with exit code 0. `npm run lint` reports 0 errors (only pre-existing warnings).

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)