### PR TITLE
ci: require release notes in the release flow

### DIFF
--- a/.github/workflows/version-and-publish.yml
+++ b/.github/workflows/version-and-publish.yml
@@ -56,6 +56,18 @@ jobs:
             exit 1
           fi
 
+      - name: Extract release notes
+        if: steps.decide.outputs.publish == 'true'
+        run: |
+          set -euo pipefail
+          bash scripts/extract-release-notes.sh "${{ steps.decide.outputs.version }}" > RELEASE_NOTES.md
+          if [ ! -s RELEASE_NOTES.md ]; then
+            echo "::error::No release notes found for v${{ steps.decide.outputs.version }} in CHANGELOG.md. The version-check gate should have caught this on the PR."
+            exit 1
+          fi
+          echo "Release notes for v${{ steps.decide.outputs.version }}:"
+          cat RELEASE_NOTES.md
+
       - name: Setup Node.js
         if: steps.decide.outputs.publish == 'true'
         uses: actions/setup-node@v4
@@ -85,7 +97,7 @@ jobs:
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "v${{ steps.decide.outputs.version }}" -m "Release v${{ steps.decide.outputs.version }}"
+          git tag -a "v${{ steps.decide.outputs.version }}" -F RELEASE_NOTES.md
           git push origin "v${{ steps.decide.outputs.version }}"
 
       - name: Publish to NPM
@@ -93,3 +105,12 @@ jobs:
         run: pnpm publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        if: steps.decide.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ steps.decide.outputs.version }}" \
+            --title "v${{ steps.decide.outputs.version }}" \
+            --notes-file RELEASE_NOTES.md

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -57,4 +57,19 @@ jobs:
             exit 1
           fi
 
-          echo "✅ $PKG_VERSION is a valid release bump (npm latest: $NPM_VERSION). Merging will publish it."
+          # 4) Required release notes: CHANGELOG.md must carry a non-empty
+          #    "## [$PKG_VERSION]" section. These become the tag message and the
+          #    GitHub Release body when the publish workflow runs on merge.
+          if [ ! -f CHANGELOG.md ]; then
+            echo "::error::Version bumped to $PKG_VERSION but CHANGELOG.md is missing. Add a '## [$PKG_VERSION]' section with release notes."
+            exit 1
+          fi
+          NOTES="$(bash scripts/extract-release-notes.sh "$PKG_VERSION")"
+          if [ -z "$NOTES" ]; then
+            echo "::error::No release notes for $PKG_VERSION. Add a non-empty '## [$PKG_VERSION]' section to CHANGELOG.md before releasing."
+            exit 1
+          fi
+
+          echo "✅ $PKG_VERSION is a valid release bump (npm latest: $NPM_VERSION) with release notes. Merging will publish it."
+          echo "Release notes for $PKG_VERSION:"
+          echo "$NOTES"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Every release **must** have a matching `## [x.y.z]` section below before it can
+be published. CI enforces this: a pull request that bumps the version in
+`package.json` fails unless this file contains a non-empty section for the new
+version (see `.github/workflows/version-check.yml`). On merge, the publish
+workflow uses that section as the annotated git tag message and the GitHub
+Release body.
+
+To cut a release: move your `## [Unreleased]` notes under a new
+`## [x.y.z] - YYYY-MM-DD` heading in the same PR that bumps the version.
+
+## [Unreleased]
+
+<!-- Add notes for the next release here. When you bump the version in
+     package.json, move these under a `## [x.y.z] - YYYY-MM-DD` heading. -->
+
+## [0.4.22]
+
+- Baseline release. History prior to this version predates this changelog; see
+  the git tags and the npm release history for earlier changes.

--- a/scripts/extract-release-notes.sh
+++ b/scripts/extract-release-notes.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Extracts a single version's release notes from CHANGELOG.md.
+#
+# Usage: extract-release-notes.sh <version> [changelog-path]
+#
+# Prints the body of the "## [<version>]" section (everything up to the next
+# "## [" heading) to stdout, with surrounding blank lines trimmed. Prints
+# nothing and exits 0 when the section is missing or empty, so callers can
+# treat empty output as "no notes". The version is matched literally, so an
+# optional "## [<version>] - YYYY-MM-DD" date suffix is fine.
+#
+# Shared by version-check.yml (the PR gate) and version-and-publish.yml (the
+# publisher) so the two cannot drift in how they read the changelog.
+set -euo pipefail
+
+version="${1:?usage: extract-release-notes.sh <version> [changelog-path]}"
+changelog="${2:-CHANGELOG.md}"
+
+[ -f "$changelog" ] || exit 0
+
+awk -v v="$version" '
+  BEGIN { target = "## [" v "]" }
+  # The section starts at a line beginning with the exact "## [<version>]".
+  index($0, target) == 1 { found = 1; next }
+  # The next "## [" heading ends the section.
+  found && /^## \[/ { exit }
+  found { lines[n++] = $0 }
+  END {
+    # Trim leading and trailing blank lines from the captured body.
+    start = 0
+    while (start < n && lines[start] ~ /^[[:space:]]*$/) start++
+    end = n - 1
+    while (end >= start && lines[end] ~ /^[[:space:]]*$/) end--
+    for (i = start; i <= end; i++) print lines[i]
+  }
+' "$changelog"


### PR DESCRIPTION
## Summary

Extends the release flow so that **human-authored release notes are required** to cut a release, and so each release also produces a GitHub Release (not just a content-free tag).

Today: `version-and-publish.yml` tags `vX.Y.Z` with a generic `"Release vX.Y.Z"` message and publishes to npm — there are no release notes anywhere, and no GitHub Release.

## How it works

- **`CHANGELOG.md`** (Keep a Changelog format) is the source of truth — one `## [x.y.z]` section per release. Seeded with an `Unreleased` section and a `0.4.22` baseline.
- **`scripts/extract-release-notes.sh`** — a shared extractor that pulls a single version's section (literal match, so a `## [x.y.z] - YYYY-MM-DD` date suffix is fine; trims surrounding blank lines). Used by **both** workflows so the gate and the publisher can't drift.
- **`version-check.yml`** (PR gate): when a PR bumps the version, it now *also* fails unless `CHANGELOG.md` has a non-empty `## [<new version>]` section. PRs that don't bump are unaffected.
- **`version-and-publish.yml`** (publish): extracts the section into `RELEASE_NOTES.md`, uses it as the annotated tag message (`git tag -F`), and runs `gh release create` to publish a matching GitHub Release.

## Notes

- This PR does **not** bump the version, so the new gate stays dormant for it — `version-check` passes cleanly.
- No new permissions needed: the publish job already has `contents: write`, and the release step uses the built-in `GITHUB_TOKEN`.
- Verified locally: extractor returns the right section, empty output for a missing version, handles dated headings and blank-line trimming; both workflows pass `yaml.safe_load`.

## Releasing after this lands

In the same PR that bumps `package.json`, move your `Unreleased` notes under a new `## [x.y.z] - YYYY-MM-DD` heading. On merge, that text becomes the tag annotation and the GitHub Release body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)