### PR TITLE
fix: atomically claim emails before sending to prevent double-send (#74)

### DIFF
--- a/src/services/MailingService.ts
+++ b/src/services/MailingService.ts
@@ -39,6 +39,50 @@ export class MailingService implements IMailingService {
     }
   }
 
+  /**
+   * Atomically claim an email for processing by transitioning it out of
+   * `expectedStatus` into `processing`.
+   *
+   * The candidate `find` in processEmails/retryFailedEmails and this status
+   * update are separate steps, so two concurrent runs (e.g. an overlapping
+   * cron tick and a per-email job) can both select the same row. To prevent
+   * double-sending we guard the transition on the row's *current* status:
+   * the bulk `update` only matches the row while it is still in
+   * `expectedStatus`, so exactly one run can move it to `processing`. The
+   * loser's `where` matches nothing and `docs` comes back empty, letting us
+   * detect that we did not win the claim and skip the row.
+   *
+   * @returns `true` if this run won the claim, `false` if another run already
+   *   claimed it (or the row no longer matches `expectedStatus`).
+   */
+  private async claimEmail(emailId: string, expectedStatus: 'failed' | 'pending'): Promise<boolean> {
+    const { docs } = await this.payload.update({
+      collection: this.emailsCollection,
+      data: {
+        lastAttemptAt: new Date().toISOString(),
+        status: 'processing',
+      },
+      where: {
+        and: [
+          {
+            id: {
+              equals: emailId,
+            },
+          },
+          {
+            status: {
+              equals: expectedStatus,
+            },
+          },
+        ],
+      },
+    })
+
+    // A non-empty `docs` means this run's guarded update matched and moved the
+    // row; an empty `docs` means another run already claimed it first.
+    return docs.length > 0
+  }
+
   private ensureInitialized(): void {
     if (!this.payload || !this.payload.db) {
       throw new Error('MailingService payload not properly initialized')
@@ -269,17 +313,15 @@ export class MailingService implements IMailingService {
     })
   }
 
-  async processEmailItem(emailId: string): Promise<void> {
-    try {
-      await this.payload.update({
-        id: emailId,
-        collection: this.emailsCollection,
-        data: {
-          lastAttemptAt: new Date().toISOString(),
-          status: 'processing',
-        },
-      })
+  async processEmailItem(emailId: string, expectedStatus: 'failed' | 'pending' = 'pending'): Promise<void> {
+    // Win the atomic claim before doing any work; if a concurrent run already
+    // claimed this row, skip it so the email is never sent twice.
+    const claimed = await this.claimEmail(emailId, expectedStatus)
+    if (!claimed) {
+      return
+    }
 
+    try {
       const email = await this.payload.findByID({
         id: emailId,
         collection: this.emailsCollection,
@@ -409,7 +451,7 @@ export class MailingService implements IMailingService {
     })
 
     for (const email of pendingEmails) {
-      await this.processEmailItem(String(email.id))
+      await this.processEmailItem(String(email.id), 'pending')
     }
   }
 
@@ -482,7 +524,7 @@ export class MailingService implements IMailingService {
     })
 
     for (const email of failedEmails) {
-      await this.processEmailItem(String(email.id))
+      await this.processEmailItem(String(email.id), 'failed')
     }
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -106,7 +106,7 @@ export interface TemplateVariables {
 }
 
 export interface MailingService {
-  processEmailItem(emailId: string): Promise<void>
+  processEmailItem(emailId: string, expectedStatus?: 'failed' | 'pending'): Promise<void>
   processEmails(): Promise<void>
   renderTemplate(templateSlug: string, variables: TemplateVariables): Promise<{ html: string; subject: string; text: string }>
   renderTemplateDocument(template: BaseEmailTemplateDocument, variables: TemplateVariables): Promise<{ html: string; subject: string; text: string }>


### PR DESCRIPTION
## Summary

Closes #74

`MailingService.processEmails` and `retryFailedEmails` `find` candidate rows (status `pending` / `failed`) and then set `status: 'processing'` one-by-one in `processEmailItem`. The SELECT and the status UPDATE were **separate, non-atomic steps**, so two concurrent runs — e.g. a cron tick overlapping the per-email job path (`processEmailById`) or two overlapping cron runs — could both select the same row and send the email twice.

## The race

1. Run A `find`s email X (`pending`).
2. Run B `find`s email X (`pending`) before A has touched it.
3. Both call `processEmailItem(X)`, both unconditionally set X to `processing`, and both send → **double-send**.

## The fix

`processEmailItem` now **atomically claims** each email before doing any work, via a guarded status transition:

- It issues a bulk `payload.update` with a `where` clause matching **both** the `id` **and** the expected current status (`pending` for the normal path, `failed` for the retry path), transitioning it to `processing`.
- Payload's bulk update returns the rows it actually changed in `docs`. Exactly one concurrent run matches the row while it is still in the expected status and gets a non-empty `docs` (it won the claim); any other run's `where` matches nothing, gets an empty `docs`, and **skips** the row.
- The expected status is threaded through from the callers: `processEmails` claims `pending → processing`, `retryFailedEmails` claims `failed → processing`. The per-email job path keeps the default `pending`.

Behavior is otherwise unchanged. The `MailingService` interface signature was updated to expose the new optional `expectedStatus` parameter.

## Checks run

- `pnpm run build` — passes
- `pnpm run lint` — passes (0 errors; pre-existing warnings only)
- `pnpm run test` — 18 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)