### PR TITLE
fix: poll payload-jobs directly so processImmediately finds the job

### DIFF
--- a/src/utils/jobPolling.ts
+++ b/src/utils/jobPolling.ts
@@ -2,6 +2,8 @@ import type { Payload } from 'payload'
 
 import type { JobPollingConfig } from '../types/index.js'
 
+import { findExistingJobs } from './jobScheduler.js'
+
 export interface PollForJobIdOptions {
   collectionSlug: string
   config?: JobPollingConfig
@@ -43,7 +45,7 @@ const DEFAULT_JOB_POLLING_CONFIG: Required<JobPollingConfig> = {
  * @throws Error if job is not found within the configured limits
  */
 export const pollForJobId = async (options: PollForJobIdOptions): Promise<PollForJobIdResult> => {
-  const { collectionSlug, emailId, logger, payload } = options
+  const { emailId, logger, payload } = options
 
   // Merge user config with defaults
   const config: Required<JobPollingConfig> = {
@@ -74,16 +76,16 @@ export const pollForJobId = async (options: PollForJobIdOptions): Promise<PollFo
       await new Promise(resolve => setTimeout(resolve, delay))
     }
 
-    // Fetch the email document to check for associated jobs
-    const emailWithJobs = await payload.findByID({
-      id: emailId,
-      collection: collectionSlug,
-    })
+    // Query the jobs collection directly rather than reading the email's `jobs`
+    // relationship: the afterChange hook intentionally never persists that
+    // relationship (it only scopes an admin dropdown via filterOptions), so the
+    // stored value stays empty. The auto-scheduled job is, however, queryable by
+    // its `input.emailId`, which is exactly what findExistingJobs does.
+    const existingJobs = await findExistingJobs(payload, emailId)
 
-    // Check if jobs array exists and has entries
-    if (emailWithJobs.jobs && emailWithJobs.jobs.length > 0) {
-      const firstJob = Array.isArray(emailWithJobs.jobs) ? emailWithJobs.jobs[0] : emailWithJobs.jobs
-      jobId = typeof firstJob === 'string' ? firstJob : String(firstJob.id || firstJob)
+    if (existingJobs.totalDocs > 0) {
+      const firstJob = existingJobs.docs[0]
+      jobId = String(firstJob.id)
 
       return {
         attempts: attempt + 1,


### PR DESCRIPTION
Closes #72

## Root cause

`sendEmail({ processImmediately: true })` calls `pollForJobId` (`src/utils/jobPolling.ts`) to wait for the auto-scheduled processing job. The poll read the email's `jobs` relationship via `findByID` and checked `email.jobs.length > 0`.

That relationship is never populated. The `jobs` field on the Emails collection only uses `filterOptions` to scope an admin dropdown — `filterOptions` does not write stored values — and the `afterChange` hook deliberately does not persist the relationship. So `email.jobs` stays empty, the poll always exhausts its attempts, and `sendEmail` throws a misleading `POLLING_TIMEOUT` / `JOB_NOT_FOUND` "no processing job found" error even though the job was created successfully.

## Fix

Poll the `payload-jobs` collection directly using the existing `findExistingJobs(payload, emailId)` helper (`src/utils/jobScheduler.ts`), which queries by `input.emailId` and `task: 'process-email'` — the fields that are actually written when the job is scheduled. The first matching job's ID is returned.

Scope of the change is intentionally minimal: only *what* is polled changed. The exponential-backoff loop, timeout/retry limits, logging, and thrown-error semantics are all preserved. The `PollForJobIdOptions.collectionSlug` field is kept on the interface to avoid a breaking signature change.

## Checks run

- `npm run build` — passes
- `npm run lint` — passes (0 errors; only pre-existing warnings, none introduced by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)