### PR TITLE
chore: issue #78 low-severity cleanup (dead code, logging, init race, error masking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,7 +507,10 @@ const result = await renderTemplate(
 ```typescript
 import { processEmails, retryFailedEmails, getMailing } from '@xtr-dev/payload-mailing'
 
-// Process pending emails manually
+// Process pending emails manually.
+// Each call handles at most 50 due-pending emails (highest priority, oldest
+// first). A larger backlog is drained across successive calls, so schedule this
+// to run repeatedly (e.g. via a cron job) to keep a large queue moving.
 await processEmails(payload: Payload): Promise<void>
 
 // Retry failed emails manually

--- a/src/services/MailingService.ts
+++ b/src/services/MailingService.ts
@@ -11,6 +11,7 @@ import type {
 } from '../types/index.js'
 
 import { sanitizeDisplayName } from '../utils/helpers.js'
+import { createContextLogger } from '../utils/logger.js'
 import { escapeHtml, serializeRichTextToHTML, serializeRichTextToText } from '../utils/richTextSerializer.js'
 
 export class MailingService implements IMailingService {
@@ -20,6 +21,12 @@ export class MailingService implements IMailingService {
   // Separate engine with auto HTML-escaping enabled, used when substituting
   // variables into the HTML body so untrusted values cannot inject markup.
   private liquidEscaped: false | Liquid | null = null
+  // Shared in-flight promise for LiquidJS initialization. Concurrent first
+  // callers await this single promise so the dynamic `import('liquidjs')` and
+  // engine construction run exactly once, even when several emails render
+  // before initialization completes.
+  private liquidInitPromise: null | Promise<void> = null
+  private logger: ReturnType<typeof createContextLogger>
   private templatesCollection: string
   public payload: Payload
 
@@ -32,6 +39,8 @@ export class MailingService implements IMailingService {
 
     const emailsConfig = config.collections?.emails
     this.emailsCollection = typeof emailsConfig === 'string' ? emailsConfig : 'emails'
+
+    this.logger = createContextLogger(payload, 'MAILING')
 
     // Use Payload's configured email adapter
     if (!this.payload.email) {
@@ -51,26 +60,15 @@ export class MailingService implements IMailingService {
   private async ensureLiquidJSInitialized(): Promise<void> {
     if (this.liquid !== null) {return} // Already initialized or failed
 
-    try {
-      const liquidModule = await import('liquidjs')
-      const { Liquid: LiquidEngine } = liquidModule
-
-      // Two engines share identical filters but differ in output handling:
-      // `liquid` emits variable output verbatim (correct for plain-text bodies
-      // and subjects), while `liquidEscaped` HTML-escapes every `{{ output }}`
-      // so untrusted variables cannot inject markup into the HTML body. Authors
-      // opt back into raw HTML per-variable with the `| raw` filter.
-      this.liquid = new LiquidEngine()
-      this.liquidEscaped = new LiquidEngine({ outputEscape: 'escape' })
-
-      this.registerLiquidFilters(this.liquid)
-      this.registerLiquidFilters(this.liquidEscaped)
-    } catch (error) {
-      console.warn('LiquidJS not available. Falling back to simple variable replacement. Install liquidjs or use a different templateEngine.')
-      // Mark both as failed to avoid retries.
-      this.liquid = false
-      this.liquidEscaped = false
+    // Cache the initialization promise so concurrent first callers all await
+    // the same run instead of each importing liquidjs and constructing their
+    // own engines (the last writer would otherwise win and the others' engines
+    // would be discarded mid-render).
+    if (!this.liquidInitPromise) {
+      this.liquidInitPromise = this.initializeLiquidJS()
     }
+
+    await this.liquidInitPromise
   }
 
   /**
@@ -97,8 +95,9 @@ export class MailingService implements IMailingService {
   }
 
   private async getTemplateBySlug(templateSlug: string): Promise<BaseEmailTemplateDocument | null> {
+    let docs
     try {
-      const { docs } = await this.payload.find({
+      ;({ docs } = await this.payload.find({
         collection: this.templatesCollection as any,
         limit: 1,
         where: {
@@ -106,13 +105,16 @@ export class MailingService implements IMailingService {
             equals: templateSlug,
           },
         },
-      })
-
-      return docs.length > 0 ? docs[0] as BaseEmailTemplateDocument : null
+      }))
     } catch (error) {
-      console.error(`Template with slug '${templateSlug}' not found:`, error)
-      return null
+      // A query failure (e.g. DB connectivity) is a genuine error, not a
+      // missing template. Log and rethrow so callers can surface it instead of
+      // silently treating it as "template not found".
+      this.logger.error(`Failed to query template with slug '${templateSlug}':`, error)
+      throw error
     }
+
+    return docs.length > 0 ? docs[0] as BaseEmailTemplateDocument : null
   }
 
   private async incrementAttempts(emailId: string): Promise<number> {
@@ -132,6 +134,34 @@ export class MailingService implements IMailingService {
     })
 
     return newAttempts
+  }
+
+  /**
+   * Performs the one-time LiquidJS engine setup. Invoked through the cached
+   * `liquidInitPromise` so the dynamic import and engine construction never run
+   * concurrently.
+   */
+  private async initializeLiquidJS(): Promise<void> {
+    try {
+      const liquidModule = await import('liquidjs')
+      const { Liquid: LiquidEngine } = liquidModule
+
+      // Two engines share identical filters but differ in output handling:
+      // `liquid` emits variable output verbatim (correct for plain-text bodies
+      // and subjects), while `liquidEscaped` HTML-escapes every `{{ output }}`
+      // so untrusted variables cannot inject markup into the HTML body. Authors
+      // opt back into raw HTML per-variable with the `| raw` filter.
+      this.liquid = new LiquidEngine()
+      this.liquidEscaped = new LiquidEngine({ outputEscape: 'escape' })
+
+      this.registerLiquidFilters(this.liquid)
+      this.registerLiquidFilters(this.liquidEscaped)
+    } catch (error) {
+      this.logger.warn('LiquidJS not available. Falling back to simple variable replacement. Install liquidjs or use a different templateEngine.', error)
+      // Mark both as failed to avoid retries.
+      this.liquid = false
+      this.liquidEscaped = false
+    }
   }
 
   /**
@@ -198,7 +228,7 @@ export class MailingService implements IMailingService {
       try {
         return await this.config.templateRenderer(template, variables)
       } catch (error) {
-        console.error('Custom template renderer error:', error)
+        this.logger.error('Custom template renderer error:', error)
         return template
       }
     }
@@ -216,7 +246,7 @@ export class MailingService implements IMailingService {
           return await liquid.parseAndRender(template, variables)
         }
       } catch (error) {
-        console.error('LiquidJS template rendering error:', error)
+        this.logger.error('LiquidJS template rendering error:', error)
       }
     }
 
@@ -228,7 +258,7 @@ export class MailingService implements IMailingService {
           return mustacheResult
         }
       } catch (error) {
-        console.warn('Mustache not available. Falling back to simple variable replacement. Install mustache package.')
+        this.logger.warn('Mustache not available. Falling back to simple variable replacement. Install mustache package.', error)
       }
     }
 
@@ -337,7 +367,7 @@ export class MailingService implements IMailingService {
             throw new Error('beforeSend hook must not remove both "html" and "text" properties')
           }
         } catch (error) {
-          console.error('Error in beforeSend hook:', error)
+          this.logger.error('Error in beforeSend hook:', error)
           throw new Error(`beforeSend hook failed: ${error instanceof Error ? error.message : 'Unknown error'}`)
         }
       }
@@ -370,7 +400,7 @@ export class MailingService implements IMailingService {
       })
 
       if (attempts >= maxAttempts) {
-        console.error(`Email ${emailId} failed permanently after ${attempts} attempts:`, error)
+        this.logger.error(`Email ${emailId} failed permanently after ${attempts} attempts:`, error)
       }
     }
   }
@@ -379,6 +409,10 @@ export class MailingService implements IMailingService {
     this.ensureInitialized()
     const currentTime = new Date().toISOString()
 
+    // Each invocation processes at most 50 due-pending emails (highest priority,
+    // oldest first). This bounds the work and memory of a single run; a backlog
+    // larger than the cap is drained across successive calls. Drive repeated
+    // calls from a scheduled job to keep a large queue moving.
     const { docs: pendingEmails } = await this.payload.find({
       collection: this.emailsCollection,
       limit: 50,

--- a/src/utils/emailProcessor.ts
+++ b/src/utils/emailProcessor.ts
@@ -44,7 +44,7 @@ export async function processJobById(payload: Payload, jobId: string): Promise<v
 
   try {
     // Run a specific job by its ID (using where clause to find the job)
-    const result = await payload.jobs.run({
+    await payload.jobs.run({
       where: {
         id: {
           equals: jobId

--- a/src/utils/richTextSerializer.ts
+++ b/src/utils/richTextSerializer.ts
@@ -200,12 +200,3 @@ function serializeNodeToText(node: SerializedLexicalNode): string {
       return ''
   }
 }
-
-/**
- * Applies Handlebars variables to richtext-generated HTML/text
- */
-export function applyVariablesToContent(content: string, variables: Record<string, any>): string {
-  // This function can be extended to handle more complex variable substitution
-  // For now, it works with the Handlebars rendering that happens later
-  return content
-}


### PR DESCRIPTION
Closes #78

Low-severity cleanup pass over the mailing plugin. Each change is small and self-contained.

## Checklist

- [x] **1. Dead code** — Removed the no-op `applyVariablesToContent` from `src/utils/richTextSerializer.ts`. It returned `content` unchanged and had no meaningful callers (variable substitution actually happens in `MailingService.renderTemplateString`). Removed rather than implemented.
- [x] **2. Unused variable** — Dropped the unused `const result =` assignment in `processJobById` (`src/utils/emailProcessor.ts`); now just `await payload.jobs.run({...})`.
- [x] **3. Logging consistency** — Routed all raw `console.error`/`console.warn` sites in `MailingService` through `createContextLogger(payload, 'MAILING')` so they share the plugin's log levels/formatting (template renderer error, LiquidJS render error, Mustache fallback, beforeSend error, permanent-failure error, LiquidJS-unavailable warning).
- [x] **4. Init race** — `ensureLiquidJSInitialized` previously let concurrent first callers each run `import('liquidjs')` and build their own engines before `this.liquid` was set. Now guarded with a cached in-flight `liquidInitPromise`, so the import and engine construction run exactly once. (The earlier "simplify init guard" commit did not close this race, so the fix was still needed.)
- [x] **5. Error masking** — `getTemplateBySlug` no longer swallows DB errors as "not found". A query failure is logged and rethrown; `null` is returned only for an empty result set.
- [x] **7. Backlog cap** — Documented the per-run `limit: 50` behavior in `processEmails` (code comment) and in the README helper-functions section, per the issue's preference to document rather than rewrite the loop (avoids overlap with concurrency-fix PRs).
- [~] **6. Tests** — The `test` script was already re-enabled to `vitest run` (not the old `echo 'disabled'`) by a prior commit, and runs the colocated unit tests under `src/`. I verified it runs green (18 tests). The `dev/int.spec.ts` / `dev/e2e.spec.ts` suites depend on a `@payload-config` alias + Payload/DB bootstrap that is not wired in this repo, so they remain behind `test:int` / `test:e2e` and were not executed here. Wiring full integration infra was out of scope for this low-risk PR.

## Checks run

- `pnpm run build` — pass (tsc)
- `pnpm run lint` — pass (0 errors; 60 pre-existing warnings, down from 72 baseline)
- `pnpm test` (`vitest run`) — 18 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)