### PR TITLE
release: 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,36 @@ To cut a release: move your `## [Unreleased]` notes under a new
 <!-- Add notes for the next release here. When you bump the version in
      package.json, move these under a `## [x.y.z] - YYYY-MM-DD` heading. -->
 
+## [0.5.0] - 2026-06-26
+
+### Added
+
+- **Reusable email layouts** (#88): configure named layouts, each with an HTML
+  wrapper and an optional plain-text wrapper, into which a template's rendered
+  body is injected at a `{{ content }}` slot. Apply one globally with
+  `defaultLayout`, override it per template, or opt a template out entirely with
+  the `none` selection.
+- **In-admin template render preview** (#88): a live, debounced preview on the
+  template edit screen that renders the draft through the selected layout with
+  sample variables, shown in a sandboxed (`sandbox=""`) iframe. Sample variables
+  are preview-only and never stored on sent emails.
+- **Template-engine adapter layer** abstracting LiquidJS, Mustache, the simple
+  replacer, and custom renderers, so layout composition applies the correct
+  escaping model for each engine.
+
+### Fixed
+
+- **Layout-variable escaping** is now uniform across every engine: a layout's
+  own variables (e.g. `{{ siteName }}`) are always HTML-escaped with no raw
+  opt-out, closing an XSS vector for user-controlled values surfaced in a layout
+  header or footer. The rendered body is still injected once, without
+  double-escaping — including on Mustache, where `{{ content }}` and
+  `{{{ content }}}` both work.
+- **`findExistingJobs`** query repaired (correct `taskSlug`, with the nested
+  `input.emailId` matched in JS) so scheduled-email deduplication works across
+  all database adapters, and the scan is now bounded instead of loading every
+  job.
+
 ## [0.4.22]
 
 - Baseline release. History prior to this version predates this changelog; see

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ To cut a release: move your `## [Unreleased]` notes under a new
 - **Template-engine adapter layer** abstracting LiquidJS, Mustache, the simple
   replacer, and custom renderers, so layout composition applies the correct
   escaping model for each engine.
+- **Required template variables**: templates can declare the variables they
+  expect (via a new **Variables** field) and mark some as required. Sending a
+  template without a required variable is rejected before the email is queued,
+  with an error naming the missing variables — preventing emails that go out
+  with unrendered placeholders or blank values. Fully opt-in; templates that
+  declare nothing are unconstrained, and the preview/`renderTemplate` paths are
+  not affected.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,25 @@ Escaping is applied to the **HTML body only**. The plain-text body and the
 subject line keep variable values verbatim, so characters like `&` are not
 turned into entities for recipients.
 
+### Required variables
+
+A template can declare the variables it expects in the **Variables** field on the
+template (each entry has a name, a Required toggle, and an optional description).
+When you send a template, every variable marked **Required** must be supplied with
+a non-empty value (`undefined`, `null`, and `''` all count as missing; `0` and
+`false` are accepted). If any are missing, the send is **rejected before the email
+is queued** with an error naming the missing variables:
+
+```
+Missing required template variable(s) for template "welcome-email": firstName, siteName
+```
+
+This prevents emails from going out with unrendered `{{ placeholders }}` or blank
+values. Templates that declare no variables (or none marked required) accept any
+input, so this is fully opt-in. Validation runs only when **sending**; the
+in-admin preview and direct `renderTemplate` calls are not constrained, so you can
+still preview a draft with partial sample data.
+
 ## Layouts
 
 Layouts let you define a reusable wrapper (header, footer, branding, container

--- a/dev/app/(frontend)/dashboard/page.tsx
+++ b/dev/app/(frontend)/dashboard/page.tsx
@@ -139,6 +139,20 @@ export default function HomePage() {
             >
               🧪 Test Interface
             </Link>
+            <Link
+              href="/sent-emails"
+              style={{
+                backgroundColor: '#8b5cf6',
+                color: 'white',
+                padding: '12px 24px',
+                borderRadius: '8px',
+                textDecoration: 'none',
+                fontWeight: '500',
+                transition: 'background-color 0.2s'
+              }}
+            >
+              📬 Sent Emails
+            </Link>
           </div>
         </div>
 

--- a/dev/app/(frontend)/sent-emails/page.tsx
+++ b/dev/app/(frontend)/sent-emails/page.tsx
@@ -1,0 +1,281 @@
+'use client'
+
+import Link from 'next/link'
+import { useCallback, useEffect, useState } from 'react'
+
+interface CapturedEmail {
+  bcc?: string
+  cc?: string
+  from?: string
+  html?: string
+  id: number
+  sentAt: string
+  subject?: string
+  text?: string
+  to?: string
+}
+
+export default function SentEmailsPage() {
+  const [emails, setEmails] = useState<CapturedEmail[]>([])
+  const [loading, setLoading] = useState<boolean>(true)
+  const [selectedId, setSelectedId] = useState<null | number>(null)
+  const [view, setView] = useState<'html' | 'text'>('html')
+
+  const fetchEmails = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await fetch('/api/sent-emails', { cache: 'no-store' })
+      const data = await res.json()
+      const list: CapturedEmail[] = data.emails ?? []
+      setEmails(list)
+      // Keep a selection if one exists; otherwise default to the newest email.
+      setSelectedId((current) =>
+        current !== null && list.some((e) => e.id === current) ? current : list[0]?.id ?? null,
+      )
+    } catch (error) {
+      console.error('Error fetching sent emails:', error)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  const clearEmails = useCallback(async () => {
+    await fetch('/api/sent-emails', { method: 'DELETE' })
+    setSelectedId(null)
+    await fetchEmails()
+  }, [fetchEmails])
+
+  useEffect(() => {
+    fetchEmails()
+  }, [fetchEmails])
+
+  const selected = emails.find((e) => e.id === selectedId) ?? null
+
+  return (
+    <div style={{ backgroundColor: '#f9fafb', minHeight: '100vh', padding: '40px 20px' }}>
+      <div style={{ margin: '0 auto', maxWidth: '1200px' }}>
+        <div style={{ alignItems: 'center', display: 'flex', gap: '16px', marginBottom: '8px' }}>
+          <Link href="/dashboard" style={{ color: '#3b82f6', fontSize: '0.9rem', textDecoration: 'none' }}>
+            ← Dashboard
+          </Link>
+        </div>
+        <div
+          style={{
+            alignItems: 'center',
+            display: 'flex',
+            justifyContent: 'space-between',
+            marginBottom: '24px',
+          }}
+        >
+          <h1 style={{ color: '#1f2937', fontSize: '2rem', fontWeight: 'bold', margin: 0 }}>
+            📬 Sent emails
+          </h1>
+          <div style={{ display: 'flex', gap: '8px' }}>
+            <button
+              disabled={loading}
+              onClick={fetchEmails}
+              style={{
+                backgroundColor: loading ? '#9ca3af' : '#6b7280',
+                border: 'none',
+                borderRadius: '6px',
+                color: 'white',
+                cursor: loading ? 'not-allowed' : 'pointer',
+                fontWeight: 500,
+                padding: '8px 16px',
+              }}
+            >
+              {loading ? 'Loading…' : 'Refresh'}
+            </button>
+            <button
+              disabled={emails.length === 0}
+              onClick={clearEmails}
+              style={{
+                backgroundColor: emails.length === 0 ? '#fca5a5' : '#ef4444',
+                border: 'none',
+                borderRadius: '6px',
+                color: 'white',
+                cursor: emails.length === 0 ? 'not-allowed' : 'pointer',
+                fontWeight: 500,
+                padding: '8px 16px',
+              }}
+            >
+              Clear
+            </button>
+          </div>
+        </div>
+
+        <p style={{ color: '#6b7280', fontSize: '0.9rem', marginBottom: '24px' }}>
+          Messages captured by the dev test email adapter (no mail is actually delivered). The
+          outbox is in-memory and resets when the dev server restarts.
+        </p>
+
+        {emails.length === 0 ? (
+          <div
+            style={{
+              backgroundColor: 'white',
+              border: '1px solid #e5e7eb',
+              borderRadius: '12px',
+              color: '#6b7280',
+              padding: '48px',
+              textAlign: 'center',
+            }}
+          >
+            No emails sent yet. Create a user or use the{' '}
+            <Link href="/mailing-test" style={{ color: '#3b82f6' }}>
+              Test interface
+            </Link>{' '}
+            to send one.
+          </div>
+        ) : (
+          <div style={{ display: 'grid', gap: '24px', gridTemplateColumns: '320px 1fr' }}>
+            {/* List */}
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+              {emails.map((email) => {
+                const active = email.id === selectedId
+                return (
+                  <button
+                    key={email.id}
+                    onClick={() => setSelectedId(email.id)}
+                    style={{
+                      backgroundColor: active ? '#eff6ff' : 'white',
+                      border: `1px solid ${active ? '#3b82f6' : '#e5e7eb'}`,
+                      borderRadius: '10px',
+                      cursor: 'pointer',
+                      padding: '14px 16px',
+                      textAlign: 'left',
+                    }}
+                  >
+                    <div
+                      style={{
+                        color: '#1f2937',
+                        fontWeight: 600,
+                        marginBottom: '4px',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {email.subject || '(no subject)'}
+                    </div>
+                    <div style={{ color: '#6b7280', fontSize: '0.8rem' }}>To: {email.to || '—'}</div>
+                    <div style={{ color: '#9ca3af', fontSize: '0.75rem' }}>
+                      {new Date(email.sentAt).toLocaleString()}
+                    </div>
+                  </button>
+                )
+              })}
+            </div>
+
+            {/* Detail */}
+            <div
+              style={{
+                backgroundColor: 'white',
+                border: '1px solid #e5e7eb',
+                borderRadius: '12px',
+                overflow: 'hidden',
+              }}
+            >
+              {selected ? (
+                <>
+                  <div style={{ borderBottom: '1px solid #eef0f2', padding: '20px 24px' }}>
+                    <h2 style={{ color: '#1f2937', fontSize: '1.25rem', margin: '0 0 12px' }}>
+                      {selected.subject || '(no subject)'}
+                    </h2>
+                    <dl style={{ display: 'grid', fontSize: '0.85rem', gap: '4px', margin: 0 }}>
+                      <MetaRow label="From" value={selected.from} />
+                      <MetaRow label="To" value={selected.to} />
+                      <MetaRow label="Cc" value={selected.cc} />
+                      <MetaRow label="Bcc" value={selected.bcc} />
+                      <MetaRow label="Sent" value={new Date(selected.sentAt).toLocaleString()} />
+                    </dl>
+                  </div>
+
+                  <div style={{ display: 'flex', gap: '8px', padding: '12px 24px' }}>
+                    {(['html', 'text'] as const).map((tab) => (
+                      <button
+                        key={tab}
+                        onClick={() => setView(tab)}
+                        style={{
+                          backgroundColor: view === tab ? '#1f2937' : '#f3f4f6',
+                          border: 'none',
+                          borderRadius: '6px',
+                          color: view === tab ? 'white' : '#374151',
+                          cursor: 'pointer',
+                          fontSize: '0.8rem',
+                          fontWeight: 500,
+                          padding: '6px 14px',
+                          textTransform: 'uppercase',
+                        }}
+                      >
+                        {tab}
+                      </button>
+                    ))}
+                  </div>
+
+                  <div style={{ padding: '0 24px 24px' }}>
+                    {view === 'html' ? (
+                      selected.html ? (
+                        // Sandboxed with no allowances: scripts and same-origin
+                        // access are disabled, matching the in-admin preview.
+                        <iframe
+                          sandbox=""
+                          srcDoc={selected.html}
+                          style={{
+                            backgroundColor: 'white',
+                            border: '1px solid #e5e7eb',
+                            borderRadius: '8px',
+                            height: '70vh',
+                            width: '100%',
+                          }}
+                          title={`Email ${selected.id} HTML`}
+                        />
+                      ) : (
+                        <Empty>No HTML part.</Empty>
+                      )
+                    ) : selected.text ? (
+                      <pre
+                        style={{
+                          backgroundColor: '#f9fafb',
+                          border: '1px solid #e5e7eb',
+                          borderRadius: '8px',
+                          color: '#1f2937',
+                          margin: 0,
+                          maxHeight: '70vh',
+                          overflow: 'auto',
+                          padding: '16px',
+                          whiteSpace: 'pre-wrap',
+                        }}
+                      >
+                        {selected.text}
+                      </pre>
+                    ) : (
+                      <Empty>No plain-text part.</Empty>
+                    )}
+                  </div>
+                </>
+              ) : (
+                <Empty>Select an email to view it.</Empty>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+  return <div style={{ color: '#9ca3af', padding: '48px', textAlign: 'center' }}>{children}</div>
+}
+
+function MetaRow({ label, value }: { label: string; value?: string }) {
+  if (!value) {
+    return null
+  }
+  return (
+    <div style={{ display: 'flex', gap: '8px' }}>
+      <dt style={{ color: '#9ca3af', minWidth: '48px' }}>{label}</dt>
+      <dd style={{ color: '#374151', margin: 0 }}>{value}</dd>
+    </div>
+  )
+}

--- a/dev/app/api/sent-emails/route.ts
+++ b/dev/app/api/sent-emails/route.ts
@@ -1,0 +1,15 @@
+import { clearSentEmails, getSentEmails } from '../../../helpers/sentOutbox.js'
+
+// Avoid any route-level caching so the page always reflects the live outbox.
+export const dynamic = 'force-dynamic'
+
+/** Returns the emails captured by the test adapter, newest first. */
+export function GET() {
+  return Response.json({ emails: getSentEmails() })
+}
+
+/** Empties the captured outbox. */
+export function DELETE() {
+  clearSentEmails()
+  return Response.json({ success: true })
+}

--- a/dev/helpers/sentOutbox.ts
+++ b/dev/helpers/sentOutbox.ts
@@ -1,0 +1,62 @@
+/**
+ * In-memory store of emails handed to the dev `testEmailAdapter`.
+ *
+ * The test adapter does not deliver mail; it logs to stdout and records each
+ * message here so the dev "Sent emails" page can show exactly what was sent.
+ * The store is intentionally ephemeral — it starts empty on every dev server
+ * restart, giving each run a fresh mailbox.
+ */
+
+export interface CapturedEmail {
+  bcc?: string
+  cc?: string
+  from?: string
+  html?: string
+  /** Monotonic id assigned on capture; newest emails have the highest id. */
+  id: number
+  /** ISO timestamp of when the adapter received the message. */
+  sentAt: string
+  subject?: string
+  text?: string
+  to?: string
+}
+
+interface Outbox {
+  emails: CapturedEmail[]
+  nextId: number
+}
+
+// Newest dev session aside, a long-running server should not accumulate mail
+// forever, so the outbox keeps only the most recent messages.
+const MAX_CAPTURED = 100
+
+// Back the outbox with `globalThis` so a single instance is shared across every
+// module graph Next.js may evaluate within one dev server process — route
+// handlers, pages, and the Payload jobs runtime. A plain module-level array can
+// be duplicated across those separate bundles; a `globalThis` slot cannot.
+const globalForOutbox = globalThis as unknown as { __sentEmailOutbox?: Outbox }
+
+const outbox: Outbox = globalForOutbox.__sentEmailOutbox ?? { emails: [], nextId: 1 }
+globalForOutbox.__sentEmailOutbox = outbox
+
+/** Records a message the test adapter received, newest first. */
+export function recordSentEmail(email: Omit<CapturedEmail, 'id' | 'sentAt'>): void {
+  outbox.emails.unshift({
+    ...email,
+    id: outbox.nextId++,
+    sentAt: new Date().toISOString(),
+  })
+  if (outbox.emails.length > MAX_CAPTURED) {
+    outbox.emails.length = MAX_CAPTURED
+  }
+}
+
+/** Returns all captured emails, newest first. */
+export function getSentEmails(): CapturedEmail[] {
+  return outbox.emails
+}
+
+/** Empties the outbox. */
+export function clearSentEmails(): void {
+  outbox.emails = []
+}

--- a/dev/helpers/testEmailAdapter.ts
+++ b/dev/helpers/testEmailAdapter.ts
@@ -1,7 +1,10 @@
 import type { EmailAdapter, SendEmailOptions } from 'payload'
 
+import { recordSentEmail } from './sentOutbox.js'
+
 /**
- * Logs all emails to stdout
+ * Logs all emails to stdout and records them in the in-memory outbox so the dev
+ * "Sent emails" page can display what was sent.
  */
 export const testEmailAdapter: EmailAdapter<void> = ({ payload }) => ({
   name: 'test-email-adapter',
@@ -11,28 +14,46 @@ export const testEmailAdapter: EmailAdapter<void> = ({ payload }) => ({
     const stringifiedTo = getStringifiedToAddress(message)
     const res = `Test email to: '${stringifiedTo}', Subject: '${message.subject}'`
     payload.logger.info({ content: message, msg: res })
+
+    // Capture the exact payload the adapter received so it can be viewed in the
+    // dev UI instead of having to scrape it from the server logs.
+    recordSentEmail({
+      bcc: stringifyAddress(message.bcc),
+      cc: stringifyAddress(message.cc),
+      from: stringifyAddress(message.from),
+      html: typeof message.html === 'string' ? message.html : undefined,
+      subject: message.subject,
+      text: typeof message.text === 'string' ? message.text : undefined,
+      to: stringifiedTo,
+    })
+
     return Promise.resolve()
   },
 })
 
 function getStringifiedToAddress(message: SendEmailOptions): string | undefined {
-  let stringifiedTo: string | undefined
+  return stringifyAddress(message.to)
+}
 
-  if (typeof message.to === 'string') {
-    stringifiedTo = message.to
-  } else if (Array.isArray(message.to)) {
-    stringifiedTo = message.to
-      .map((to: { address: string } | string) => {
-        if (typeof to === 'string') {
-          return to
-        } else if (to.address) {
-          return to.address
-        }
-        return ''
-      })
-      .join(', ')
-  } else if (message.to?.address) {
-    stringifiedTo = message.to.address
+/** Renders any of nodemailer's accepted address shapes to a display string. */
+function stringifyAddress(
+  value:
+    | Array<{ address?: string; name?: string } | string>
+    | { address?: string; name?: string }
+    | string
+    | undefined,
+): string | undefined {
+  if (!value) {
+    return undefined
   }
-  return stringifiedTo
+  if (typeof value === 'string') {
+    return value
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => (typeof entry === 'string' ? entry : entry?.address ?? ''))
+      .filter(Boolean)
+      .join(', ')
+  }
+  return value.address
 }

--- a/dev/seed.ts
+++ b/dev/seed.ts
@@ -150,7 +150,7 @@ export const seed = async (payload: Payload) => {
                     format: 0,
                     mode: 'normal',
                     style: '',
-                    text: 'Get started by exploring the admin panel and creating your own email templates. Your account was created on {{formatDate createdAt "long"}}.',
+                    text: 'Get started by exploring the admin panel and creating your own email templates. Your account was created on {{ createdAt | formatDate: "long" }}.',
                     type: 'text',
                     version: 1,
                   },
@@ -200,6 +200,14 @@ export const seed = async (payload: Payload) => {
             version: 1,
           },
         },
+        // Declared variables. firstName and siteName are required, so sending
+        // this template without them (e.g. with empty {} variables) is rejected
+        // before any email is queued.
+        variables: [
+          { name: 'firstName', description: "Recipient's first name", required: true },
+          { name: 'siteName', description: 'Product / site name shown in the copy', required: true },
+          { name: 'createdAt', description: 'Account creation date (ISO string)', required: false },
+        ],
       },
     })
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xtr-dev/payload-mailing",
-  "version": "0.4.22",
+  "version": "0.5.0",
   "description": "Template-based email system with scheduling and job processing for PayloadCMS",
   "type": "module",
   "main": "dist/index.js",

--- a/src/collections/EmailTemplates.ts
+++ b/src/collections/EmailTemplates.ts
@@ -126,6 +126,43 @@ export const createEmailTemplatesCollection = (
       }),
       required: true,
     },
+    {
+      name: 'variables',
+      type: 'array',
+      admin: {
+        description:
+          'Declare the variables this template expects. Variables marked Required must be supplied with a non-empty value when sending, otherwise the send is rejected before any email is queued. Leave empty to accept any variables.',
+      },
+      fields: [
+        {
+          name: 'name',
+          type: 'text',
+          admin: {
+            description: 'Variable name as referenced in the template, e.g. firstName (without the {{ }}).',
+          },
+          required: true,
+        },
+        {
+          name: 'required',
+          type: 'checkbox',
+          admin: {
+            description: 'Reject sends that omit this variable or pass an empty value.',
+          },
+          defaultValue: false,
+        },
+        {
+          name: 'description',
+          type: 'text',
+          admin: {
+            description: 'Optional note describing what this variable is for.',
+          },
+        },
+      ],
+      labels: {
+        plural: 'Variables',
+        singular: 'Variable',
+      },
+    },
     // Only present when layouts are configured; filtered out otherwise.
     ...([createLayoutField(layoutNames)].filter(Boolean) as Field[]),
     // In-admin render preview (sampleVariables + preview UI); empty when disabled.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,6 +35,17 @@ export interface BaseEmailDocument {
   variables?: JSONValue
 }
 
+/**
+ * A variable a template declares it expects. Used to validate that callers
+ * supply the variables a template depends on: when `required` is true, sending
+ * the template without a non-empty value for `name` is rejected.
+ */
+export interface TemplateVariableDefinition {
+  description?: null | string
+  name: string
+  required?: boolean | null
+}
+
 export interface BaseEmailTemplateDocument {
   content?: any
   createdAt?: Date | null | string
@@ -46,6 +57,9 @@ export interface BaseEmailTemplateDocument {
   slug: string
   subject?: null | string
   updatedAt?: Date | null | string
+  // Variables this template declares it expects; required ones are validated at
+  // send time. Absent for drafts (e.g. the in-admin preview), which skips checks.
+  variables?: null | TemplateVariableDefinition[]
 }
 
 export type TemplateRendererHook = (template: string, variables: Record<string, any>) => Promise<string> | string

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -2,6 +2,8 @@ import type { Payload } from 'payload'
 
 import type { BaseEmailTemplateDocument, MailingContext, PayloadID, PayloadRelation, TemplateVariables } from '../types/index.js'
 
+import { validateRequiredTemplateVariables } from './templateVariables.js'
+
 /**
  * Parse and validate email addresses
  * @internal
@@ -169,10 +171,15 @@ export const renderTemplateWithId = async (
     throw new Error(`Template not found: ${templateSlug}`)
   }
 
-  const templateDoc = templateDocs[0]
+  const templateDoc = templateDocs[0] as unknown as BaseEmailTemplateDocument
+
+  // Reject the send before anything is queued when the template declares
+  // required variables the caller did not supply, rather than dispatching an
+  // email with the variables left as empty placeholders.
+  validateRequiredTemplateVariables(templateDoc, variables)
 
   // Render using the document directly to avoid duplicate lookup
-  const rendered = await mailing.service.renderTemplateDocument(templateDoc as unknown as BaseEmailTemplateDocument, variables)
+  const rendered = await mailing.service.renderTemplateDocument(templateDoc, variables)
 
   return {
     ...rendered,

--- a/src/utils/templateVariables.test.ts
+++ b/src/utils/templateVariables.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'vitest'
+
+import { validateRequiredTemplateVariables } from './templateVariables.js'
+
+const template = (variables: any) => ({ slug: 'welcome', variables }) as any
+
+describe('validateRequiredTemplateVariables', () => {
+  test('passes when all required variables are present', () => {
+    const tpl = template([
+      { name: 'firstName', required: true },
+      { name: 'siteName', required: false },
+    ])
+    expect(() => validateRequiredTemplateVariables(tpl, { firstName: 'Ada' })).not.toThrow()
+  })
+
+  test('throws listing every missing required variable', () => {
+    const tpl = template([
+      { name: 'firstName', required: true },
+      { name: 'orderId', required: true },
+      { name: 'siteName', required: false },
+    ])
+    expect(() => validateRequiredTemplateVariables(tpl, { siteName: 'Acme' })).toThrow(
+      /Missing required template variable\(s\) for template "welcome": firstName, orderId/,
+    )
+  })
+
+  test('treats null and empty string as missing, but 0 and false as present', () => {
+    const tpl = template([
+      { name: 'a', required: true },
+      { name: 'b', required: true },
+      { name: 'count', required: true },
+      { name: 'flag', required: true },
+    ])
+    expect(() => validateRequiredTemplateVariables(tpl, { a: null, b: '', count: 0, flag: false })).toThrow(
+      /a, b/,
+    )
+    expect(() => validateRequiredTemplateVariables(tpl, { a: 'x', b: 'y', count: 0, flag: false })).not.toThrow()
+  })
+
+  test('does nothing when the template declares no variables', () => {
+    expect(() => validateRequiredTemplateVariables(template(undefined), {})).not.toThrow()
+    expect(() => validateRequiredTemplateVariables(template([]), {})).not.toThrow()
+  })
+
+  test('ignores declared variables that are not marked required', () => {
+    const tpl = template([{ name: 'firstName', required: false }, { name: 'siteName' }])
+    expect(() => validateRequiredTemplateVariables(tpl, {})).not.toThrow()
+  })
+})

--- a/src/utils/templateVariables.ts
+++ b/src/utils/templateVariables.ts
@@ -1,0 +1,36 @@
+import type { BaseEmailTemplateDocument, TemplateVariables } from '../types/index.js'
+
+/**
+ * A variable value counts as "missing" when it was never supplied or is blank.
+ * `null` and `''` are treated the same as `undefined` so a required variable
+ * cannot be satisfied by an empty placeholder. `0` and `false` are valid values.
+ */
+const isMissing = (value: unknown): boolean =>
+  value === undefined || value === null || value === ''
+
+/**
+ * Throws when a template declares required variables that the caller did not
+ * supply. Templates with no `variables` declarations (including the draft
+ * documents used for the in-admin preview) are not constrained, so this is a
+ * no-op for them. Called on the send path so an email is never queued with a
+ * required variable left unrendered.
+ */
+export const validateRequiredTemplateVariables = (
+  template: Pick<BaseEmailTemplateDocument, 'slug' | 'variables'>,
+  variables: TemplateVariables,
+): void => {
+  const declared = template.variables
+  if (!Array.isArray(declared) || declared.length === 0) {
+    return
+  }
+
+  const missing = declared
+    .filter((definition) => definition?.required && definition.name && isMissing(variables?.[definition.name]))
+    .map((definition) => definition.name)
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required template variable(s) for template "${template.slug}": ${missing.join(', ')}`,
+    )
+  }
+}


### PR DESCRIPTION
Cuts the **0.5.0** release. PR #92 merged its code at `e0cf027`, *before* the version bump landed (the PR head was lagging at merge time), so `package.json` on main stayed at `0.4.22` and nothing published. This PR carries the three commits that were left on the merged branch:

- `chore(release): 0.5.0` — version bump + CHANGELOG `## [0.5.0]` section.
- `feat: required template variables` — opt-in per-template required-variable declarations, validated on the send path.
- `chore(dev): add a Sent emails viewer backed by the test adapter` — dev-only tooling (not in the published package).

On merge, `version-and-publish.yml` will tag `v0.5.0`, publish to npm, and create the GitHub Release from the CHANGELOG notes.

Verified: tsc clean · ESLint 0 errors · 36/36 tests · changelog extracts non-empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)