### PR TITLE
ci: npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/version-and-publish.yml
+++ b/.github/workflows/version-and-publish.yml
@@ -15,7 +15,11 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
+      # contents: write — push the release tag and create the GitHub Release.
+      # id-token: write — mint the short-lived OIDC token npm uses for trusted
+      # publishing (no long-lived NPM_TOKEN) and for build provenance.
       contents: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -79,6 +83,11 @@ jobs:
         if: steps.decide.outputs.publish == 'true'
         uses: pnpm/action-setup@v4
 
+      # Trusted publishing (OIDC) requires npm >= 11.5.1; Node 20 ships npm 10.x.
+      - name: Update npm for trusted publishing
+        if: steps.decide.outputs.publish == 'true'
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         if: steps.decide.outputs.publish == 'true'
         run: pnpm install --frozen-lockfile
@@ -100,11 +109,12 @@ jobs:
           git tag -a "v${{ steps.decide.outputs.version }}" -F RELEASE_NOTES.md
           git push origin "v${{ steps.decide.outputs.version }}"
 
+      # Authenticated via OIDC trusted publishing (configured on npm for this
+      # repo + workflow), so no NODE_AUTH_TOKEN is needed. --provenance attaches
+      # a build attestation, which the public repo + id-token permission allow.
       - name: Publish to NPM
         if: steps.decide.outputs.publish == 'true'
-        run: pnpm publish --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public
 
       - name: Create GitHub Release
         if: steps.decide.outputs.publish == 'true'


### PR DESCRIPTION
Replaces the long-lived `NPM_TOKEN` in the publish workflow with npm **OIDC trusted publishing** (now configured on npm for this repo + `version-and-publish.yml`). This fixes the `E404` publish failure, which was an auth problem — the token lacked publish rights to the `@xtr-dev` scope.

Changes to `version-and-publish.yml`:
- `id-token: write` permission (mints the OIDC token).
- Update npm to ≥ 11.5.1 (Node 20 ships npm 10.x; trusted publishing requires 11.5.1+).
- Publish via `npm publish --provenance --access public` — no secret, with build provenance (repo is public).

The dangling `v0.5.0` tag from the failed run has been deleted, so on merge the publish workflow will tag `v0.5.0`, publish 0.5.0 via OIDC, and create the Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)