### PR TITLE
Deny collection access by default and streamline README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,29 @@ To cut a release: move your `## [Unreleased]` notes under a new
 <!-- Add notes for the next release here. When you bump the version in
      package.json, move these under a `## [x.y.z] - YYYY-MM-DD` heading. -->
 
+### Changed
+
+- **Secure-by-default collection access (breaking).** The `emails` and
+  `email-templates` collections now **deny every operation by default** instead
+  of inheriting Payload's built-in default (which grants access to any
+  authenticated user). This prevents accidentally exposing email content,
+  recipients, and templates in apps that have non-admin/front-end users. The
+  plugin's own sending, scheduling, and rendering are unaffected — they run
+  through Payload's Local API, which bypasses access control. **Action
+  required:** grant the access your app needs via the plugin's
+  `collections.emails.access` / `collections.templates.access` overrides. Your
+  `access` functions are merged on top of the deny-all defaults, so any
+  operation you don't override stays denied. See the new **Access Control**
+  section in the README.
+
+### Docs
+
+- Rewrote the README to be shorter and focused on essential usage, added an
+  **Access Control** section, and corrected stale references (a non-existent
+  `onReady` option, an `attemptCount` field, and a `sendTemplateEmailTask` /
+  `send-template-email` job task that the plugin does not expose — its
+  processing job is registered automatically).
+
 ## [0.5.0] - 2026-06-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,32 +2,32 @@
 
 [![npm version](https://img.shields.io/npm/v/@xtr-dev/payload-mailing.svg)](https://www.npmjs.com/package/@xtr-dev/payload-mailing)
 
-A template-based email system with scheduling and job processing for PayloadCMS 3.x.
+Template-based email for PayloadCMS 3.x — with layouts, scheduling, and job-queue
+processing. No custom APIs: everything lives in Payload collections you already
+know how to use.
 
-⚠️ **Pre-release Warning**: This package is currently in active development (v0.0.x). Breaking changes may occur before v1.0.0. Not recommended for production use.
+> ⚠️ **Pre-release** (v0.x). Breaking changes may occur before v1.0.0.
 
 ## Features
 
-- 📧 Template-based emails with LiquidJS, Mustache, or custom engines
-- 🧱 Reusable email layouts (header/footer/branding wrappers)
-- 👁️ In-admin live render preview (HTML + plain text) with sample variables
-- ⏰ Email scheduling for future delivery
-- 🔄 Automatic retry mechanism for failed sends
-- 🎯 Full TypeScript support with generated Payload types
-- 📋 Job queue integration via PayloadCMS
-- 🔧 Uses Payload collections directly - no custom APIs
+- 📧 Templates with LiquidJS (default), Mustache, simple, or a custom engine
+- 🧱 Reusable layouts (header/footer/branding wrappers)
+- 👁️ In-admin live render preview (HTML + plain text)
+- ⏰ Scheduling and automatic retries via the Payload job queue
+- 🔒 Collections locked down by default — you opt in to who can access them
+- 🎯 Full TypeScript support
 
 ## Installation
 
 ```bash
-npm install @xtr-dev/payload-mailing
-# or
 pnpm add @xtr-dev/payload-mailing
-# or
-yarn add @xtr-dev/payload-mailing
+# npm install / yarn add also work
 ```
 
 ## Quick Start
+
+Add the plugin and an [email adapter](https://payloadcms.com/docs/email/overview)
+to your Payload config:
 
 ```typescript
 import { buildConfig } from 'payload'
@@ -35,417 +35,291 @@ import { mailingPlugin } from '@xtr-dev/payload-mailing'
 import { nodemailerAdapter } from '@payloadcms/email-nodemailer'
 
 export default buildConfig({
-  // ... your config
   email: nodemailerAdapter({
     defaultFromAddress: 'noreply@yoursite.com',
     defaultFromName: 'Your Site',
-    transport: {
-      host: 'smtp.gmail.com',
-      port: 587,
-      auth: {
-        user: process.env.EMAIL_USER,
-        pass: process.env.EMAIL_PASS,
-      },
-    },
+    transport: { /* your SMTP transport */ },
   }),
   plugins: [
     mailingPlugin({
       defaultFrom: 'noreply@yoursite.com',
-      defaultFromName: 'Your Site Name',
+      defaultFromName: 'Your Site',
       retryAttempts: 3,
       retryDelay: 300000, // 5 minutes
+      // Required: grant access to the collections — see "Access Control" below.
+      collections: {
+        emails: { access: { /* ... */ } },
+        templates: { access: { /* ... */ } },
+      },
     }),
   ],
 })
 ```
 
-## Imports
-
-```typescript
-// Main plugin
-import { mailingPlugin } from '@xtr-dev/payload-mailing'
-
-// Helper functions
-import { sendEmail, renderTemplate, processEmails } from '@xtr-dev/payload-mailing'
-
-// Job tasks
-import { sendTemplateEmailTask } from '@xtr-dev/payload-mailing'
-
-// Types
-import type { MailingPluginConfig, SendEmailOptions } from '@xtr-dev/payload-mailing'
-```
-
-## Usage
-
-```typescript
-import { sendEmail } from '@xtr-dev/payload-mailing'
-
-// Using templates
-const email = await sendEmail(payload, {
-  template: {
-    slug: 'welcome-email',
-    variables: { firstName: 'John', welcomeUrl: 'https://example.com' }
-  },
-  data: {
-    to: 'user@example.com',
-    scheduledAt: new Date(Date.now() + 24 * 60 * 60 * 1000), // Schedule for later
-    priority: 1
-  }
-})
-
-// Direct email
-const directEmail = await payload.create({
-  collection: 'emails',
-  data: {
-    to: ['user@example.com'],
-    subject: 'Welcome!',
-    html: '<h1>Welcome!</h1>',
-    text: 'Welcome!'
-  }
-})
-```
-
-## Template Engines
-
-### LiquidJS (Default)
-Modern template syntax with logic support:
-```liquid
-{% if user.isPremium %}
-  Welcome Premium Member {{user.name}}!
-{% else %}
-  Welcome {{user.name}}!
-{% endif %}
-```
-
-### Mustache
-Logic-less templates:
-```mustache
-{{#user.isPremium}}
-  Welcome Premium Member {{user.name}}!
-{{/user.isPremium}}
-{{^user.isPremium}}
-  Welcome {{user.name}}!
-{{/user.isPremium}}
-```
-
-### Simple Variables
-Basic `{{variable}}` replacement:
-```text
-Welcome {{user.name}}! Your account expires on {{expireDate}}.
-```
-
-### Custom Renderer
-Bring your own template engine:
-```typescript
-mailingPlugin({
-  templateRenderer: async (template, variables) => {
-    return handlebars.compile(template)(variables)
-  }
-})
-```
-
-### Variable escaping & untrusted data
-
-Rich-text content is HTML-escaped during serialization, and template
-**variables substituted into the HTML body are HTML-escaped by default** so that
-untrusted values (names, user input, etc.) cannot inject markup or scripts into
-the email. This applies to the built-in engines:
-
-- **LiquidJS** (default) and **Simple** — HTML-body variables are auto-escaped.
-  In LiquidJS, opt a specific variable back into raw HTML with the `raw` filter:
-  `{{ trustedHtml | raw }}`.
-- **Mustache** — already escapes `{{ var }}` by default; use `{{{ var }}}` for raw.
-- **Custom renderer** — you are responsible for escaping your own output.
-
-Escaping is applied to the **HTML body only**. The plain-text body and the
-subject line keep variable values verbatim, so characters like `&` are not
-turned into entities for recipients.
-
-### Required variables
-
-A template can declare the variables it expects in the **Variables** field on the
-template (each entry has a name, a Required toggle, and an optional description).
-When you send a template, every variable marked **Required** must be supplied with
-a non-empty value (`undefined`, `null`, and `''` all count as missing; `0` and
-`false` are accepted). If any are missing, the send is **rejected before the email
-is queued** with an error naming the missing variables:
-
-```
-Missing required template variable(s) for template "welcome-email": firstName, siteName
-```
-
-This prevents emails from going out with unrendered `{{ placeholders }}` or blank
-values. Templates that declare no variables (or none marked required) accept any
-input, so this is fully opt-in. Validation runs only when **sending**; the
-in-admin preview and direct `renderTemplate` calls are not constrained, so you can
-still preview a draft with partial sample data.
-
-## Layouts
-
-Layouts let you define a reusable wrapper (header, footer, branding, container
-table, etc.) once and apply it to many templates. The rendered template body is
-injected into the layout at a `{{ content }}` slot, producing the final HTML and
-plain text.
-
-### Configuring layouts
-
-Layouts are declared as a **config map** of named layouts in the plugin options.
-Keeping them in code means they are versioned with your application, require no
-new collection or database migration, and carry the lowest risk:
-
-```typescript
-mailingPlugin({
-  // ...
-  layouts: {
-    branded: {
-      html: `<!DOCTYPE html>
-<html>
-  <body style="font-family: sans-serif;">
-    <header><img src="https://example.com/logo.png" alt="{{ siteName }}"></header>
-    <main>{{ content }}</main>
-    <footer>© {{ siteName }} — <a href="{{ unsubscribeUrl }}">Unsubscribe</a></footer>
-  </body>
-</html>`,
-      text: `{{ siteName }}
-------------------------------
-
-{{ content }}
-
-------------------------------
-Unsubscribe: {{ unsubscribeUrl }}`,
-    },
-  },
-  // Applied to templates that do not pick their own layout:
-  defaultLayout: 'branded',
-})
-```
-
-### The `{{ content }}` slot
-
-Each layout must contain a `{{ content }}` slot where the rendered body is
-injected. Layout strings run through the **same template engine** as templates,
-so they can use the same variables and filters. The plugin renders the layout
-with all of your template variables plus a `content` variable equal to the
-already-rendered body.
-
-- The **HTML** layout wraps the HTML body via its `{{ content }}` slot.
-- The optional **`text`** layout wraps the plain-text body via its own
-  `{{ content }}` slot, keeping the text/MIME alternative correct. If a layout
-  omits `text`, the plain-text body is sent **unwrapped** (current behavior).
-
-#### Escaping in layouts
-
-The plugin keeps the same escaping guarantees inside layouts as it does in
-template bodies, regardless of which engine you use:
-
-- **`content` is injected verbatim.** The body was already escaped during its
-  own render pass, so it is never escaped again — no double-encoding.
-- **A layout's own variables (e.g. `{{ siteName }}`) are always HTML-escaped**
-  in the HTML layout — with no opt-out, on every engine — so untrusted values
-  surfaced in a header or footer cannot inject markup. (The plain-text layout
-  emits them verbatim.) `{{ name | raw }}` in LiquidJS and `{{{ name }}}` in
-  Mustache do **not** unescape a layout variable: it is escaped before the
-  engine runs, so the raw syntax just emits the already-escaped text. If you
-  need static HTML in a layout (e.g. a styled footer or nav bar), embed it
-  directly in the layout template string rather than passing it as a variable.
-- **Mustache** users may write the `content` slot as either `{{ content }}` or
-  `{{{ content }}}` — both inject the body raw. (Mustache normally escapes
-  `{{ }}` output; the plugin handles the `content` slot so it is never
-  double-escaped either way.)
-
-### Selecting a layout per template
-
-When one or more layouts are configured, templates gain a **Layout** select
-field in the admin UI. The options are derived from your configured layout names
-plus:
-
-- **Use default** — defers to the plugin's `defaultLayout` (this is the default).
-- **None** — explicitly sends the body without any layout, even when a
-  `defaultLayout` is configured.
-
-### Back-compat
-
-Layouts are fully opt-in. If you configure no `layouts` and no `defaultLayout`,
-nothing changes: the **Layout** field is not added to the collection and every
-template renders **exactly as before**. A template set to **None** also renders
-unwrapped.
-
-> **Roadmap:** A collection-based layout source (editor-managed layouts) may be
-> offered in a future release as an alternative to the config map.
-
-## In-admin render preview
-
-The templates collection includes a live **Preview** panel in the edit view that
-renders the current (unsaved) template and shows both outputs side by side:
-
-- the **HTML** output, in a sandboxed `iframe` (scripts disabled, so preview
-  content can never execute), and
-- the **plain-text** output, in a monospace panel.
-
-A **Sample variables** JSON field seeds the preview — e.g. `{ "firstName": "Ada" }`.
-Edit the content, subject, sample variables, or selected layout and the preview
-re-renders (debounced). Rendering goes through the same server-side pipeline used
-to send real emails (`POST <api>/mailing/preview-template`), so the preview honors
-the configured **template engine** and the selected **layout** rather than
-reimplementing serialization in the browser. The `sampleVariables` field is used
-only for previewing — it is never stored on sent emails.
-
-### Registering the client component
-
-The preview ships a client component (`@xtr-dev/payload-mailing/client#TemplatePreview`),
-so after adding or upgrading the plugin you must regenerate your import map:
-
-```bash
-payload generate:importmap
-```
-
-### Disabling the preview
-
-The preview is enabled by default. To omit the preview field and its client
-component (for example, if you prefer not to regenerate the import map), set:
-
-```typescript
-mailingPlugin({
-  adminPreview: false,
-})
-```
-
-The preview render endpoint is always registered; only the admin field and its
-component are gated by this option.
-
-## Templates
-
-Use `{{}}` to insert data in templates:
-
-- `{{user.name}}` - User data from variables
-- `{{ createdAt | formatDate: "short" }}` - Built-in date formatting
-- `{{ amount | formatCurrency: "USD" }}` - Currency formatting
-
-### Template Structure
-
-Templates include both subject and body content:
-
-```liquid
-<!-- Subject Template -->
-Welcome {{user.name}} to {{siteName}}!
-
-<!-- Body Template -->
-# Hello {{user.name}}! 👋
-
-{% if user.isPremium %}
-**Welcome Premium Member!**
-
-Your premium features are now active:
-- Priority support
-- Advanced analytics
-- Custom integrations
-{% else %}
-Welcome to {{siteName}}!
-
-**Ready to get started?**
-- Complete your profile
-- Explore our features
-- [Upgrade to Premium]({{upgradeUrl}})
-{% endif %}
-
----
-**Account Details:**
-- Created: {{ user.createdAt | formatDate: "long" }}
-- Email: {{user.email}}
-- Plan: {{user.plan | capitalize}}
-
-Need help? Reply to this email or visit our [help center]({{helpUrl}}).
-
-Best regards,
-The {{siteName}} Team
-```
-
-### Example Usage
-
-```typescript
-// Create template in admin panel, then use:
-const { html, text, subject } = await renderTemplate(payload, 'welcome-email', {
-  user: {
-    name: 'John Doe',
-    email: 'john@example.com',
-    isPremium: false,
-    plan: 'free',
-    createdAt: new Date()
-  },
-  siteName: 'MyApp',
-  upgradeUrl: 'https://myapp.com/upgrade',
-  helpUrl: 'https://myapp.com/help'
-})
-
-// Results in:
-// subject: "Welcome John Doe to MyApp!"
-// html: "<h1>Hello John Doe! 👋</h1><p>Welcome to MyApp!</p>..."
-// text: "Hello John Doe! Welcome to MyApp! Ready to get started?..."
-```
-
-## Configuration
-
-### Plugin Options
-
-```typescript
-mailingPlugin({
-  // Template engine
-  templateEngine: 'liquidjs',  // 'liquidjs' | 'mustache' | 'simple'
-
-  // Custom template renderer
-  templateRenderer: async (template: string, variables: Record<string, any>) => {
-    return yourCustomEngine.render(template, variables)
-  },
-
-  // Email settings
-  defaultFrom: 'noreply@yoursite.com',
-  defaultFromName: 'Your Site',
-  retryAttempts: 3,              // Number of retry attempts
-  retryDelay: 300000,            // 5 minutes between retries
-
-  // Collection customization
-  collections: {
-    templates: 'email-templates', // Custom collection name
-    emails: 'emails'             // Custom collection name
-  },
-
-  // Hooks
-  beforeSend: async (options, email) => {
-    // Modify email before sending
-    options.headers = { 'X-Campaign-ID': email.campaignId }
-    return options
-  },
-
-  onReady: async (payload) => {
-    // Plugin initialization complete
-    console.log('Mailing plugin ready!')
-  }
-})
-```
-
-### Collection Overrides
-
-Customize collections with access controls and custom fields:
+This registers two collections under a **Mailing** group in the admin:
+`email-templates` (author templates) and `emails` (delivery + status tracking).
+
+## Access Control
+
+**The mailing collections deny every operation by default.** Payload's built-in
+default would grant access to *any* authenticated user — in an app with
+front-end/non-admin users that quietly exposes email content, recipients, and
+templates. To avoid accidentally publicizing them, this plugin ships a
+deny-all default and asks you to grant access explicitly.
+
+Until you do, no one can read or manage these collections through the REST /
+GraphQL API or the admin panel. (Sending still works: the plugin's own
+sending, scheduling, and rendering run through Payload's Local API, which
+bypasses access control.)
+
+Grant the access your app needs via the collection overrides. Your `access`
+functions are merged **on top of** the deny-all defaults, so any operation you
+don't specify stays denied:
 
 ```typescript
 mailingPlugin({
   collections: {
     emails: {
       access: {
-        read: ({ req: { user } }) => user?.role === 'admin',
-        create: ({ req: { user } }) => !!user,
+        read:   ({ req: { user } }) => user?.role === 'admin',
+        create: ({ req: { user } }) => Boolean(user),
         update: ({ req: { user } }) => user?.role === 'admin',
-        delete: ({ req: { user } }) => user?.role === 'admin'
+        delete: ({ req: { user } }) => user?.role === 'admin',
       },
+    },
+    templates: {
+      access: {
+        read:   ({ req: { user } }) => Boolean(user),
+        create: ({ req: { user } }) => user?.role === 'admin',
+        update: ({ req: { user } }) => user?.role === 'admin',
+        delete: ({ req: { user } }) => user?.role === 'admin',
+      },
+    },
+  },
+})
+```
+
+`access` follows the standard [Payload access control](https://payloadcms.com/docs/access-control/collections)
+API. The same override object also accepts custom `fields`, `admin`, `hooks`,
+etc. — see [Collection Overrides](#collection-overrides).
+
+## Sending Email
+
+```typescript
+import { sendEmail } from '@xtr-dev/payload-mailing'
+
+// From a template
+await sendEmail(payload, {
+  template: { slug: 'welcome-email', variables: { firstName: 'John' } },
+  data: {
+    to: 'user@example.com',
+    scheduledAt: new Date(Date.now() + 60 * 60 * 1000), // optional: send later
+    priority: 1,                                        // optional: 1 = highest
+  },
+})
+
+// Or with your own content (no template)
+await sendEmail(payload, {
+  data: { to: 'user@example.com', subject: 'Hi', html: '<h1>Hi</h1>' },
+})
+```
+
+Emails are queued and processed in the background. Pass
+`processImmediately: true` to send synchronously instead.
+
+## Templates
+
+Author templates in the admin (**Mailing → Email Templates**). Each has a
+`slug`, `subject`, rich-text `content`, and optional declared `variables`.
+Reference data with `{{ }}`:
+
+```liquid
+Hello {{ user.name }}!
+{% if user.isPremium %}Welcome, premium member!{% endif %}
+Joined {{ user.createdAt | formatDate: "long" }}
+```
+
+Render a template without sending:
+
+```typescript
+import { renderTemplate } from '@xtr-dev/payload-mailing'
+
+const { html, text, subject } = await renderTemplate(payload, 'welcome-email', {
+  user: { name: 'John', isPremium: false, createdAt: new Date() },
+})
+```
+
+### Template engines
+
+Choose the engine with `templateEngine`, or plug in your own:
+
+| Engine       | Syntax                                          |
+| ------------ | ----------------------------------------------- |
+| `liquidjs`   | `{{ var }}`, `{% if %}` — **default**            |
+| `mustache`   | `{{ var }}`, `{{#section}}…{{/section}}`         |
+| `simple`     | plain `{{ var }}` replacement                    |
+| custom       | `templateRenderer: (tpl, vars) => string`        |
+
+### Variable escaping
+
+Variables substituted into the **HTML body are HTML-escaped by default**, so
+untrusted values can't inject markup. Opt a value back into raw HTML with the
+`raw` filter in LiquidJS (`{{ trusted | raw }}`) or triple-staches in Mustache
+(`{{{ trusted }}}`). The subject and plain-text body are emitted verbatim. With a
+custom renderer you are responsible for your own escaping.
+
+### Required variables
+
+A template can mark declared variables as **Required**. Sending it without a
+non-empty value for one is rejected *before the email is queued*, with an error
+naming what's missing — preventing emails that go out with blank placeholders.
+Fully opt-in; templates that declare nothing are unconstrained.
+
+## Layouts
+
+Define reusable wrappers (header, footer, branding) once and inject a template's
+rendered body at the `{{ content }}` slot:
+
+```typescript
+mailingPlugin({
+  layouts: {
+    branded: {
+      html: `<html><body><header>…</header><main>{{ content }}</main></body></html>`,
+      text: `{{ content }}\n\n— Unsubscribe: {{ unsubscribeUrl }}`, // optional
+    },
+  },
+  defaultLayout: 'branded', // applied to templates that don't pick their own
+})
+```
+
+When any layout is configured, templates gain a **Layout** select in the admin
+(with **Use default** and **None** options). Layouts run through the same engine
+as templates. A layout's own variables are always HTML-escaped (no opt-out); the
+already-escaped `content` is injected without double-encoding. Fully opt-in —
+with no `layouts`/`defaultLayout`, templates render exactly as before.
+
+## In-admin Preview
+
+The template edit view includes a live **Preview** panel that renders the
+current draft (through the selected layout) to HTML and plain text, seeded by a
+**Sample variables** JSON field. Rendering uses the same server-side pipeline as
+real sends. Sample variables are preview-only and never stored.
+
+The preview ships a client component, so regenerate your import map after
+installing or upgrading:
+
+```bash
+payload generate:importmap
+```
+
+Disable it with `adminPreview: false` (useful if you'd rather not regenerate the
+import map); the render endpoint stays registered either way.
+
+## Jobs & Scheduling
+
+The plugin **registers its own processing job automatically** — there's no task
+for you to add. Every email you send (via `sendEmail`, or by creating an `emails`
+document) queues a job to render and deliver it in the background, honoring
+`scheduledAt` for future sends and retrying failures automatically.
+
+You just need a job **runner** so the queue gets processed. Either let Payload
+run jobs on a schedule:
+
+```typescript
+export default buildConfig({
+  jobs: {
+    autoRun: [{ cron: '* * * * *', queue: 'default', limit: 10 }],
+  },
+})
+```
+
+…or drain the queue yourself (e.g. from your own cron) with `processEmails` —
+each call handles up to 50 due emails, highest priority and oldest first:
+
+```typescript
+import { processEmails } from '@xtr-dev/payload-mailing'
+await processEmails(payload)
+```
+
+For a one-off synchronous send that skips the queue, pass
+`sendEmail(payload, { processImmediately: true, … })`.
+
+Emails track a `status` of `pending` → `processing` → `sent` / `failed`. Monitor
+them under **Mailing → Emails** or query the `emails` collection directly.
+
+## Configuration
+
+```typescript
+mailingPlugin({
+  // Sending
+  defaultFrom: 'noreply@yoursite.com',
+  defaultFromName: 'Your Site',
+  retryAttempts: 3,
+  retryDelay: 300000,          // ms between retries
+  queue: 'default',            // job queue name
+
+  // Templating
+  templateEngine: 'liquidjs',  // 'liquidjs' | 'mustache' | 'simple'
+  templateRenderer: async (tpl, vars) => yourEngine.render(tpl, vars),
+  layouts: { /* … */ },
+  defaultLayout: 'branded',
+
+  // Admin
+  adminPreview: true,          // set false to omit the preview field
+
+  // Collections — rename and/or override (access, fields, hooks, …)
+  collections: {
+    emails: 'emails',          // string = rename, or an override object
+    templates: 'email-templates',
+  },
+
+  // Hook: mutate the send options right before delivery
+  beforeSend: async (options, email) => {
+    options.headers = { 'X-Campaign-ID': email.campaignId }
+    return options
+  },
+})
+```
+
+### Collection Overrides
+
+Pass an object (instead of a string) for `collections.emails` /
+`collections.templates` to layer any Payload collection config onto the built-in
+one — `access` (see [Access Control](#access-control)), custom `fields`, `admin`,
+`hooks`, and so on:
+
+```typescript
+mailingPlugin({
+  collections: {
+    emails: {
+      access: { /* … */ },
       fields: [
-        {
-          name: 'campaignId',
-          type: 'text',
-          admin: { position: 'sidebar' }
-        }
-      ]
-    }
-  }
+        { name: 'campaignId', type: 'text', admin: { position: 'sidebar' } },
+      ],
+    },
+  },
+})
+```
+
+## API Reference
+
+| Export                                   | Purpose                                              |
+| ---------------------------------------- | ---------------------------------------------------- |
+| `sendEmail(payload, options)`            | Queue (or immediately send) a template/direct email. |
+| `renderTemplate(payload, slug, vars)`    | Render `{ html, text, subject }` without sending.    |
+| `processEmails(payload)`                 | Process up to 50 due-pending emails.                 |
+| `retryFailedEmails(payload)`             | Re-queue failed emails.                              |
+| `getMailing(payload)`                    | Get the mailing context (service, config, slugs).    |
+
+`sendEmail` is generic over your generated `Email` type for type-safe custom
+fields:
+
+```typescript
+import type { Email } from './payload-types'
+
+await sendEmail<Email>(payload, {
+  template: { slug: 'welcome', variables: { name: 'John' } },
+  data: { to: 'user@example.com', campaignId: 'q1-launch' }, // custom fields typed
 })
 ```
 
@@ -453,381 +327,14 @@ mailingPlugin({
 
 - PayloadCMS ^3.0.0
 - Node.js ^18.20.2 || >=20.9.0
-- pnpm ^9 || ^10
 
-## Job Processing
+## Contributing
 
-### When to Use Jobs vs Direct Sending
-
-**Use Jobs for:**
-- Bulk email campaigns (performance)
-- Scheduled emails (future delivery)
-- Background processing (non-blocking)
-- Retry handling (automatic retries)
-- High-volume sending (queue management)
-
-**Use Direct Sending for:**
-- Immediate transactional emails
-- Single recipient emails
-- Simple use cases
-- When you need immediate feedback
-
-### Setup
-
-```typescript
-import { sendTemplateEmailTask } from '@xtr-dev/payload-mailing'
-
-export default buildConfig({
-  jobs: {
-    tasks: [sendTemplateEmailTask]
-  }
-})
-```
-
-### Queue Template Emails
-
-```typescript
-// Basic template email
-await payload.jobs.queue({
-  task: 'send-template-email',
-  input: {
-    templateSlug: 'welcome-email',
-    to: ['user@example.com'],
-    variables: { firstName: 'John' }
-  }
-})
-
-// Scheduled email
-await payload.jobs.queue({
-  task: 'send-template-email',
-  input: {
-    templateSlug: 'reminder-email',
-    to: ['user@example.com'],
-    variables: { eventName: 'Product Launch' },
-    scheduledAt: new Date('2024-01-15T10:00:00Z').toISOString(),
-    priority: 1
-  }
-})
-
-// Immediate processing (bypasses queue)
-await payload.jobs.queue({
-  task: 'send-template-email',
-  input: {
-    processImmediately: true,
-    templateSlug: 'urgent-notification',
-    to: ['admin@example.com'],
-    variables: { alertMessage: 'System critical error' }
-  }
-})
-```
-
-### Bulk Operations
-
-```typescript
-// Send to multiple recipients efficiently
-const recipients = ['user1@example.com', 'user2@example.com', 'user3@example.com']
-
-for (const email of recipients) {
-  await payload.jobs.queue({
-    task: 'send-template-email',
-    input: {
-      templateSlug: 'newsletter',
-      to: [email],
-      variables: { unsubscribeUrl: `https://example.com/unsubscribe/${email}` },
-      priority: 3 // Lower priority for bulk emails
-    }
-  })
-}
-```
-
-## Email Status & Monitoring
-
-### Status Types
-
-Emails are tracked with these statuses:
-- `pending` - Waiting to be sent
-- `processing` - Currently being sent
-- `sent` - Successfully delivered
-- `failed` - Failed to send (will retry automatically)
-
-### Query Email Status
-
-```typescript
-// Check specific email status
-const email = await payload.findByID({
-  collection: 'emails',
-  id: 'email-id'
-})
-console.log(`Email status: ${email.status}`)
-
-// Find emails by status
-const pendingEmails = await payload.find({
-  collection: 'emails',
-  where: {
-    status: { equals: 'pending' }
-  },
-  sort: 'createdAt'
-})
-
-// Find failed emails for retry
-const failedEmails = await payload.find({
-  collection: 'emails',
-  where: {
-    status: { equals: 'failed' },
-    attemptCount: { less_than: 3 }
-  }
-})
-
-// Monitor scheduled emails
-const scheduledEmails = await payload.find({
-  collection: 'emails',
-  where: {
-    scheduledAt: { greater_than: new Date() },
-    status: { equals: 'pending' }
-  }
-})
-```
-
-### Admin Panel Monitoring
-
-Navigate to **Mailing > Emails** in your Payload admin to:
-- View email delivery status and timestamps
-- See error messages for failed deliveries
-- Track retry attempts and next retry times
-- Monitor scheduled email queue
-- Filter by status, recipient, or date range
-- Export email reports for analysis
-
-## Environment Variables
-
-```bash
-EMAIL_HOST=smtp.gmail.com
-EMAIL_PORT=587
-EMAIL_USER=your-email@gmail.com
-EMAIL_PASS=your-app-password
-EMAIL_FROM=noreply@yoursite.com
-```
-
-## API Reference
-
-### `sendEmail<T>(payload, options)`
-
-Send emails with full type safety using your generated Payload types.
-
-```typescript
-import { sendEmail } from '@xtr-dev/payload-mailing'
-import type { Email } from './payload-types'
-
-const email = await sendEmail<Email>(payload, {
-  template?: {
-    slug: string                    // Template slug
-    variables: Record<string, any>  // Template variables
-  },
-  data: {
-    to: string | string[]          // Recipients
-    cc?: string | string[]         // CC recipients
-    bcc?: string | string[]        // BCC recipients
-    subject?: string               // Email subject (overrides template)
-    html?: string                  // HTML content (overrides template)
-    text?: string                  // Text content (overrides template)
-    scheduledAt?: Date             // Schedule for later
-    priority?: number              // Priority (1-5, 1 = highest)
-    // ... your custom fields from Email collection
-  },
-  collectionSlug?: string          // Custom collection name (default: 'emails')
-})
-```
-
-### `renderTemplate(payload, slug, variables)`
-
-Render a template without sending an email.
-
-```typescript
-import { renderTemplate } from '@xtr-dev/payload-mailing'
-
-const result = await renderTemplate(
-  payload: Payload,
-  slug: string,
-  variables: Record<string, any>
-): Promise<{
-  html: string    // Rendered HTML content
-  text: string    // Rendered text content
-  subject: string // Rendered subject line
-}>
-```
-
-### Helper Functions
-
-```typescript
-import { processEmails, retryFailedEmails, getMailing } from '@xtr-dev/payload-mailing'
-
-// Process pending emails manually.
-// Each call handles at most 50 due-pending emails (highest priority, oldest
-// first). A larger backlog is drained across successive calls, so schedule this
-// to run repeatedly (e.g. via a cron job) to keep a large queue moving.
-await processEmails(payload: Payload): Promise<void>
-
-// Retry failed emails manually
-await retryFailedEmails(payload: Payload): Promise<void>
-
-// Get mailing service instance
-const mailing = getMailing(payload: Payload): MailingService
-```
-
-### Job Task Types
-
-```typescript
-import type { SendTemplateEmailInput } from '@xtr-dev/payload-mailing'
-
-interface SendTemplateEmailInput {
-  templateSlug: string              // Template to use
-  to: string[]                      // Recipients
-  cc?: string[]                     // CC recipients
-  bcc?: string[]                    // BCC recipients
-  variables: Record<string, any>    // Template variables
-  scheduledAt?: string              // ISO date string for scheduling
-  priority?: number                 // Priority (1-5)
-  processImmediately?: boolean      // Send immediately (default: false)
-  [key: string]: any               // Your custom email collection fields
-}
-```
-
-## Troubleshooting
-
-### Common Issues
-
-#### Templates not rendering
-```typescript
-// Check template exists
-const template = await payload.findByID({
-  collection: 'email-templates',
-  id: 'your-template-slug'
-})
-
-// Verify template engine configuration
-mailingPlugin({
-  templateEngine: 'liquidjs', // Ensure correct engine
-})
-```
-
-#### Emails stuck in pending status
-```typescript
-// Manually process email queue
-import { processEmails } from '@xtr-dev/payload-mailing'
-await processEmails(payload)
-
-// Check for processing errors
-const pendingEmails = await payload.find({
-  collection: 'emails',
-  where: { status: { equals: 'pending' } }
-})
-```
-
-#### SMTP connection errors
-```bash
-# Verify environment variables
-EMAIL_HOST=smtp.gmail.com
-EMAIL_PORT=587
-EMAIL_USER=your-email@gmail.com
-EMAIL_PASS=your-app-password  # Use app password, not regular password
-
-# Test connection
-curl -v telnet://smtp.gmail.com:587
-```
-
-#### Template variables not working
-```typescript
-// Ensure variables match template syntax
-const variables = {
-  user: { name: 'John' },  // For {{user.name}}
-  welcomeUrl: 'https://...' // For {{welcomeUrl}}
-}
-
-// Check for typos in template
-{% if user.isPremium %}  <!-- Correct -->
-{% if user.isPremimum %} <!-- Typo - won't work -->
-```
-
-### Error Handling
-
-```typescript
-try {
-  const email = await sendEmail(payload, {
-    template: { slug: 'welcome', variables: { name: 'John' } },
-    data: { to: 'user@example.com' }
-  })
-} catch (error) {
-  if (error.message.includes('Template not found')) {
-    // Handle missing template
-    console.error('Template does not exist:', error.templateSlug)
-  } else if (error.message.includes('SMTP')) {
-    // Handle email delivery issues
-    console.error('Email delivery failed:', error.details)
-  } else {
-    // Handle other errors
-    console.error('Unexpected error:', error)
-  }
-}
-```
-
-### Debug Mode
-
-Enable detailed logging:
-
-```bash
-# Set environment variable
-PAYLOAD_AUTOMATION_LOG_LEVEL=debug npm run dev
-
-# Or in your code
-mailingPlugin({
-  onReady: async (payload) => {
-    console.log('Mailing plugin initialized')
-  },
-  beforeSend: async (options, email) => {
-    console.log('Sending email:', { to: options.to, subject: options.subject })
-    return options
-  }
-})
-```
+Issues and PRs welcome at the
+[GitHub repository](https://github.com/xtr-dev/payload-mailing). See
+[DEVELOPMENT.md](./DEVELOPMENT.md) for the local setup (zero-config in-memory
+MongoDB, test interface, and admin panel).
 
 ## License
 
 MIT
-
-## Contributing
-
-### Development Setup
-
-```bash
-# Clone the repository
-git clone https://github.com/xtr-dev/payload-mailing.git
-cd payload-mailing
-
-# Install dependencies
-pnpm install
-
-# Build the package
-pnpm build
-
-# Run tests
-pnpm test
-
-# Link for local development
-pnpm link --global
-```
-
-### Testing
-
-```bash
-# Run unit tests
-pnpm test
-
-# Run integration tests
-pnpm test:integration
-
-# Test with different PayloadCMS versions
-pnpm test:payload-3.0
-pnpm test:payload-latest
-```
-
-Issues and pull requests welcome at [GitHub repository](https://github.com/xtr-dev/payload-mailing)

--- a/README.md
+++ b/README.md
@@ -2,32 +2,20 @@
 
 [![npm version](https://img.shields.io/npm/v/@xtr-dev/payload-mailing.svg)](https://www.npmjs.com/package/@xtr-dev/payload-mailing)
 
-Template-based email for PayloadCMS 3.x — with layouts, scheduling, and job-queue
-processing. No custom APIs: everything lives in Payload collections you already
-know how to use.
+Template-based email for PayloadCMS 3.x — templates, layouts, scheduling, and
+job-queue processing, all through Payload collections you already know.
 
 > ⚠️ **Pre-release** (v0.x). Breaking changes may occur before v1.0.0.
 
-## Features
-
-- 📧 Templates with LiquidJS (default), Mustache, simple, or a custom engine
-- 🧱 Reusable layouts (header/footer/branding wrappers)
-- 👁️ In-admin live render preview (HTML + plain text)
-- ⏰ Scheduling and automatic retries via the Payload job queue
-- 🔒 Collections locked down by default — you opt in to who can access them
-- 🎯 Full TypeScript support
-
-## Installation
+## Install
 
 ```bash
 pnpm add @xtr-dev/payload-mailing
-# npm install / yarn add also work
 ```
 
 ## Quick Start
 
-Add the plugin and an [email adapter](https://payloadcms.com/docs/email/overview)
-to your Payload config:
+Add the plugin plus an [email adapter](https://payloadcms.com/docs/email/overview):
 
 ```typescript
 import { buildConfig } from 'payload'
@@ -35,46 +23,34 @@ import { mailingPlugin } from '@xtr-dev/payload-mailing'
 import { nodemailerAdapter } from '@payloadcms/email-nodemailer'
 
 export default buildConfig({
-  email: nodemailerAdapter({
-    defaultFromAddress: 'noreply@yoursite.com',
-    defaultFromName: 'Your Site',
-    transport: { /* your SMTP transport */ },
-  }),
+  email: nodemailerAdapter({ defaultFromAddress: 'noreply@yoursite.com', transport: { /* SMTP */ } }),
   plugins: [
     mailingPlugin({
       defaultFrom: 'noreply@yoursite.com',
-      defaultFromName: 'Your Site',
-      retryAttempts: 3,
-      retryDelay: 300000, // 5 minutes
-      // Required: grant access to the collections — see "Access Control" below.
       collections: {
-        emails: { access: { /* ... */ } },
-        templates: { access: { /* ... */ } },
+        // Required — collections deny all access by default. See "Access Control".
+        emails: { access: { read: ({ req: { user } }) => Boolean(user) } },
+        templates: { access: { read: ({ req: { user } }) => Boolean(user) } },
       },
     }),
   ],
 })
 ```
 
-This registers two collections under a **Mailing** group in the admin:
-`email-templates` (author templates) and `emails` (delivery + status tracking).
+This adds two collections under a **Mailing** admin group: `email-templates`
+(author templates) and `emails` (delivery + status tracking).
 
 ## Access Control
 
 **The mailing collections deny every operation by default.** Payload's built-in
-default would grant access to *any* authenticated user — in an app with
-front-end/non-admin users that quietly exposes email content, recipients, and
-templates. To avoid accidentally publicizing them, this plugin ships a
-deny-all default and asks you to grant access explicitly.
+default grants access to *any* authenticated user, which in an app with
+front-end/non-admin users would expose email content, recipients, and templates.
+Until you grant access explicitly, no one can read or manage these collections
+via the REST/GraphQL API or admin panel — but sending still works, since the
+plugin sends through Payload's Local API (which bypasses access control).
 
-Until you do, no one can read or manage these collections through the REST /
-GraphQL API or the admin panel. (Sending still works: the plugin's own
-sending, scheduling, and rendering run through Payload's Local API, which
-bypasses access control.)
-
-Grant the access your app needs via the collection overrides. Your `access`
-functions are merged **on top of** the deny-all defaults, so any operation you
-don't specify stays denied:
+Grant access via the collection overrides. Your functions are merged **on top
+of** the deny-all default, so any operation you don't set stays denied:
 
 ```typescript
 mailingPlugin({
@@ -87,21 +63,13 @@ mailingPlugin({
         delete: ({ req: { user } }) => user?.role === 'admin',
       },
     },
-    templates: {
-      access: {
-        read:   ({ req: { user } }) => Boolean(user),
-        create: ({ req: { user } }) => user?.role === 'admin',
-        update: ({ req: { user } }) => user?.role === 'admin',
-        delete: ({ req: { user } }) => user?.role === 'admin',
-      },
-    },
+    // templates: { access: { … } }
   },
 })
 ```
 
-`access` follows the standard [Payload access control](https://payloadcms.com/docs/access-control/collections)
-API. The same override object also accepts custom `fields`, `admin`, `hooks`,
-etc. — see [Collection Overrides](#collection-overrides).
+`access` is the standard [Payload access control](https://payloadcms.com/docs/access-control/collections)
+API. The same override object also accepts custom `fields`, `hooks`, `admin`, etc.
 
 ## Sending Email
 
@@ -113,228 +81,95 @@ await sendEmail(payload, {
   template: { slug: 'welcome-email', variables: { firstName: 'John' } },
   data: {
     to: 'user@example.com',
-    scheduledAt: new Date(Date.now() + 60 * 60 * 1000), // optional: send later
-    priority: 1,                                        // optional: 1 = highest
+    scheduledAt: new Date(Date.now() + 3600_000), // optional: send later
+    priority: 1,                                   // optional: 1 = highest
   },
 })
 
-// Or with your own content (no template)
+// Or with your own content
 await sendEmail(payload, {
   data: { to: 'user@example.com', subject: 'Hi', html: '<h1>Hi</h1>' },
 })
 ```
 
-Emails are queued and processed in the background. Pass
-`processImmediately: true` to send synchronously instead.
+Emails are queued and sent in the background (see [Jobs](#jobs)). Pass
+`processImmediately: true` to send synchronously.
 
 ## Templates
 
-Author templates in the admin (**Mailing → Email Templates**). Each has a
-`slug`, `subject`, rich-text `content`, and optional declared `variables`.
-Reference data with `{{ }}`:
+Author templates in the admin (**Mailing → Email Templates**): a `slug`,
+`subject`, rich-text `content`, and optional declared `variables`. Reference
+data with `{{ }}`, e.g. `Hello {{ user.name }}!` or
+`{{ createdAt | formatDate: "long" }}`.
 
-```liquid
-Hello {{ user.name }}!
-{% if user.isPremium %}Welcome, premium member!{% endif %}
-Joined {{ user.createdAt | formatDate: "long" }}
-```
+- **Engines** — set `templateEngine` to `liquidjs` (default), `mustache`, or
+  `simple`, or supply `templateRenderer: (tpl, vars) => string` for your own.
+- **Escaping** — HTML-body variables are HTML-escaped by default (opt out with
+  LiquidJS `{{ x | raw }}` / Mustache `{{{ x }}}`); subject and text are verbatim.
+- **Required variables** — mark declared variables Required and a send missing
+  one is rejected *before it's queued*. Opt-in; declare nothing to skip checks.
 
-Render a template without sending:
-
-```typescript
-import { renderTemplate } from '@xtr-dev/payload-mailing'
-
-const { html, text, subject } = await renderTemplate(payload, 'welcome-email', {
-  user: { name: 'John', isPremium: false, createdAt: new Date() },
-})
-```
-
-### Template engines
-
-Choose the engine with `templateEngine`, or plug in your own:
-
-| Engine       | Syntax                                          |
-| ------------ | ----------------------------------------------- |
-| `liquidjs`   | `{{ var }}`, `{% if %}` — **default**            |
-| `mustache`   | `{{ var }}`, `{{#section}}…{{/section}}`         |
-| `simple`     | plain `{{ var }}` replacement                    |
-| custom       | `templateRenderer: (tpl, vars) => string`        |
-
-### Variable escaping
-
-Variables substituted into the **HTML body are HTML-escaped by default**, so
-untrusted values can't inject markup. Opt a value back into raw HTML with the
-`raw` filter in LiquidJS (`{{ trusted | raw }}`) or triple-staches in Mustache
-(`{{{ trusted }}}`). The subject and plain-text body are emitted verbatim. With a
-custom renderer you are responsible for your own escaping.
-
-### Required variables
-
-A template can mark declared variables as **Required**. Sending it without a
-non-empty value for one is rejected *before the email is queued*, with an error
-naming what's missing — preventing emails that go out with blank placeholders.
-Fully opt-in; templates that declare nothing are unconstrained.
+Render without sending: `renderTemplate(payload, slug, vars)` →
+`{ html, text, subject }`.
 
 ## Layouts
 
-Define reusable wrappers (header, footer, branding) once and inject a template's
-rendered body at the `{{ content }}` slot:
+Define reusable wrappers once and inject a template's body at `{{ content }}`:
 
 ```typescript
 mailingPlugin({
   layouts: {
-    branded: {
-      html: `<html><body><header>…</header><main>{{ content }}</main></body></html>`,
-      text: `{{ content }}\n\n— Unsubscribe: {{ unsubscribeUrl }}`, // optional
-    },
+    branded: { html: `<html><body><main>{{ content }}</main></body></html>` },
   },
   defaultLayout: 'branded', // applied to templates that don't pick their own
 })
 ```
 
-When any layout is configured, templates gain a **Layout** select in the admin
-(with **Use default** and **None** options). Layouts run through the same engine
-as templates. A layout's own variables are always HTML-escaped (no opt-out); the
-already-escaped `content` is injected without double-encoding. Fully opt-in —
-with no `layouts`/`defaultLayout`, templates render exactly as before.
+Templates then get a **Layout** select (with **Use default** / **None**). Layout
+variables are always HTML-escaped; `content` is injected without double-encoding.
+Fully opt-in — with no layouts, templates render exactly as before.
 
-## In-admin Preview
+## Jobs
 
-The template edit view includes a live **Preview** panel that renders the
-current draft (through the selected layout) to HTML and plain text, seeded by a
-**Sample variables** JSON field. Rendering uses the same server-side pipeline as
-real sends. Sample variables are preview-only and never stored.
+The plugin registers its processing job automatically — nothing to add. Sending
+(or creating an `emails` doc) queues a background job that honors `scheduledAt`
+and retries failures. You just need a job **runner**: either Payload's
+`jobs.autoRun` cron, or call `processEmails(payload)` yourself (drains up to 50
+due emails per call, highest priority first). Emails track a `status` of
+`pending → processing → sent / failed`.
 
-The preview ships a client component, so regenerate your import map after
-installing or upgrading:
+## Options
 
-```bash
-payload generate:importmap
-```
+| Option | Description |
+| --- | --- |
+| `defaultFrom` / `defaultFromName` | Default sender for emails that don't set one. |
+| `retryAttempts` / `retryDelay` | Retry count and delay (ms) for failed sends. |
+| `queue` | Job queue name (default `'default'`). |
+| `templateEngine` | `'liquidjs'` \| `'mustache'` \| `'simple'`. |
+| `templateRenderer` | Custom `(tpl, vars) => string \| Promise<string>`. |
+| `layouts` / `defaultLayout` | Named layout wrappers and the default one. |
+| `adminPreview` | Live in-admin render preview; `true` by default. Set `false` to skip it (and the `payload generate:importmap` step). |
+| `collections` | Rename (`'slug'`) or override (`{ access, fields, … }`) the emails/templates collections. |
+| `beforeSend` | `(options, email) => options` hook to mutate the send just before delivery. |
 
-Disable it with `adminPreview: false` (useful if you'd rather not regenerate the
-import map); the render endpoint stays registered either way.
+## API
 
-## Jobs & Scheduling
+| Export | Purpose |
+| --- | --- |
+| `sendEmail(payload, options)` | Queue (or immediately send) a template/direct email. |
+| `renderTemplate(payload, slug, vars)` | Render `{ html, text, subject }` without sending. |
+| `processEmails(payload)` | Process up to 50 due-pending emails. |
+| `retryFailedEmails(payload)` | Re-queue failed emails. |
+| `getMailing(payload)` | Get the mailing context (service, config, slugs). |
 
-The plugin **registers its own processing job automatically** — there's no task
-for you to add. Every email you send (via `sendEmail`, or by creating an `emails`
-document) queues a job to render and deliver it in the background, honoring
-`scheduledAt` for future sends and retrying failures automatically.
-
-You just need a job **runner** so the queue gets processed. Either let Payload
-run jobs on a schedule:
-
-```typescript
-export default buildConfig({
-  jobs: {
-    autoRun: [{ cron: '* * * * *', queue: 'default', limit: 10 }],
-  },
-})
-```
-
-…or drain the queue yourself (e.g. from your own cron) with `processEmails` —
-each call handles up to 50 due emails, highest priority and oldest first:
-
-```typescript
-import { processEmails } from '@xtr-dev/payload-mailing'
-await processEmails(payload)
-```
-
-For a one-off synchronous send that skips the queue, pass
-`sendEmail(payload, { processImmediately: true, … })`.
-
-Emails track a `status` of `pending` → `processing` → `sent` / `failed`. Monitor
-them under **Mailing → Emails** or query the `emails` collection directly.
-
-## Configuration
-
-```typescript
-mailingPlugin({
-  // Sending
-  defaultFrom: 'noreply@yoursite.com',
-  defaultFromName: 'Your Site',
-  retryAttempts: 3,
-  retryDelay: 300000,          // ms between retries
-  queue: 'default',            // job queue name
-
-  // Templating
-  templateEngine: 'liquidjs',  // 'liquidjs' | 'mustache' | 'simple'
-  templateRenderer: async (tpl, vars) => yourEngine.render(tpl, vars),
-  layouts: { /* … */ },
-  defaultLayout: 'branded',
-
-  // Admin
-  adminPreview: true,          // set false to omit the preview field
-
-  // Collections — rename and/or override (access, fields, hooks, …)
-  collections: {
-    emails: 'emails',          // string = rename, or an override object
-    templates: 'email-templates',
-  },
-
-  // Hook: mutate the send options right before delivery
-  beforeSend: async (options, email) => {
-    options.headers = { 'X-Campaign-ID': email.campaignId }
-    return options
-  },
-})
-```
-
-### Collection Overrides
-
-Pass an object (instead of a string) for `collections.emails` /
-`collections.templates` to layer any Payload collection config onto the built-in
-one — `access` (see [Access Control](#access-control)), custom `fields`, `admin`,
-`hooks`, and so on:
-
-```typescript
-mailingPlugin({
-  collections: {
-    emails: {
-      access: { /* … */ },
-      fields: [
-        { name: 'campaignId', type: 'text', admin: { position: 'sidebar' } },
-      ],
-    },
-  },
-})
-```
-
-## API Reference
-
-| Export                                   | Purpose                                              |
-| ---------------------------------------- | ---------------------------------------------------- |
-| `sendEmail(payload, options)`            | Queue (or immediately send) a template/direct email. |
-| `renderTemplate(payload, slug, vars)`    | Render `{ html, text, subject }` without sending.    |
-| `processEmails(payload)`                 | Process up to 50 due-pending emails.                 |
-| `retryFailedEmails(payload)`             | Re-queue failed emails.                              |
-| `getMailing(payload)`                    | Get the mailing context (service, config, slugs).    |
-
-`sendEmail` is generic over your generated `Email` type for type-safe custom
-fields:
-
-```typescript
-import type { Email } from './payload-types'
-
-await sendEmail<Email>(payload, {
-  template: { slug: 'welcome', variables: { name: 'John' } },
-  data: { to: 'user@example.com', campaignId: 'q1-launch' }, // custom fields typed
-})
-```
+`sendEmail<Email>(…)` is generic over your generated `Email` type for type-safe
+custom fields.
 
 ## Requirements
 
-- PayloadCMS ^3.0.0
-- Node.js ^18.20.2 || >=20.9.0
+PayloadCMS ^3.0.0 · Node.js ^18.20.2 || >=20.9.0
 
 ## Contributing
 
-Issues and PRs welcome at the
-[GitHub repository](https://github.com/xtr-dev/payload-mailing). See
-[DEVELOPMENT.md](./DEVELOPMENT.md) for the local setup (zero-config in-memory
-MongoDB, test interface, and admin panel).
-
-## License
-
-MIT
+Issues and PRs welcome at the [repository](https://github.com/xtr-dev/payload-mailing);
+see [DEVELOPMENT.md](./DEVELOPMENT.md) for local setup. MIT licensed.

--- a/dev/payload.config.ts
+++ b/dev/payload.config.ts
@@ -123,6 +123,28 @@ export default buildConfig({
         retryDelay: 60000, // 1 minute for dev
         queue: 'default',
 
+        // The mailing collections deny all access by default (see
+        // src/collections/access.ts). Grant access explicitly here so the admin
+        // panel can manage them — restrict to authenticated users in this demo.
+        collections: {
+          emails: {
+            access: {
+              create: ({ req: { user } }) => Boolean(user),
+              delete: ({ req: { user } }) => Boolean(user),
+              read: ({ req: { user } }) => Boolean(user),
+              update: ({ req: { user } }) => Boolean(user),
+            },
+          },
+          templates: {
+            access: {
+              create: ({ req: { user } }) => Boolean(user),
+              delete: ({ req: { user } }) => Boolean(user),
+              read: ({ req: { user } }) => Boolean(user),
+              update: ({ req: { user } }) => Boolean(user),
+            },
+          },
+        },
+
         // Example designed layout. The rendered template body is injected into
         // the `{{ content }}` slot, giving every email a shared branded header
         // and footer. Layout strings run through the same engine as templates,

--- a/src/collections/EmailTemplates.ts
+++ b/src/collections/EmailTemplates.ts
@@ -2,6 +2,8 @@ import type { CollectionConfig, Field, RichTextField } from 'payload'
 
 import { lexicalEditor } from '@payloadcms/richtext-lexical'
 
+import { denyAllAccess } from './access.js'
+
 /**
  * Builds the optional `layout` select field. Its options are derived from the
  * layout names configured in plugin options, plus an explicit "None" option so
@@ -72,6 +74,9 @@ export const createEmailTemplatesCollection = (
   enablePreview = false,
 ): CollectionConfig => ({
   slug: 'email-templates',
+  // Deny all access by default; grant explicitly via the plugin's
+  // `collections.templates.access` override. See src/collections/access.ts.
+  access: { ...denyAllAccess },
   admin: {
     defaultColumns: ['name', 'subject', 'updatedAt'],
     group: 'Mailing',

--- a/src/collections/Emails.ts
+++ b/src/collections/Emails.ts
@@ -3,9 +3,13 @@ import type { CollectionConfig } from 'payload'
 import { getMailing, resolveID } from '../utils/helpers.js'
 import { ensureEmailJob } from '../utils/jobScheduler.js'
 import { createContextLogger } from '../utils/logger.js'
+import { denyAllAccess } from './access.js'
 
 const Emails: CollectionConfig = {
   slug: 'emails',
+  // Deny all access by default; grant explicitly via the plugin's
+  // `collections.emails.access` override. See src/collections/access.ts.
+  access: { ...denyAllAccess },
   admin: {
     defaultColumns: ['subject', 'to', 'status', 'jobs', 'scheduledAt', 'sentAt'],
     description: 'Email delivery and status tracking',

--- a/src/collections/access.ts
+++ b/src/collections/access.ts
@@ -1,0 +1,27 @@
+import type { CollectionConfig } from 'payload'
+
+/**
+ * Denies an operation for every request. Payload's Local API (used internally by
+ * this plugin to create/find/update emails, templates and jobs) bypasses access
+ * control by default, so denying here does not affect the plugin's own sending
+ * or rendering — it only governs the REST/GraphQL API and the admin panel.
+ */
+const deny = () => false
+
+/**
+ * Secure-by-default access control applied to the mailing collections.
+ *
+ * Payload's built-in default grants access to *any* authenticated user, which in
+ * apps with non-admin/front-end users would expose email content, recipients and
+ * templates. To avoid accidentally publicizing these collections, the plugin
+ * denies every operation by default. Grant the access your app needs explicitly
+ * via the plugin's `collections.emails` / `collections.templates` overrides — the
+ * plugin merges your `access` on top of these defaults, so any operation you do
+ * not override stays denied.
+ */
+export const denyAllAccess: NonNullable<CollectionConfig['access']> = {
+  create: deny,
+  delete: deny,
+  read: deny,
+  update: deny,
+}

--- a/src/plugin.access.test.ts
+++ b/src/plugin.access.test.ts
@@ -1,0 +1,55 @@
+import type { Config } from 'payload'
+
+import { describe, expect, it } from 'vitest'
+
+import { mailingPlugin } from './plugin.js'
+
+/**
+ * These tests lock in the secure-by-default access behavior: the emails and
+ * templates collections must deny every operation unless the host app grants
+ * access explicitly through the plugin's collection overrides.
+ */
+const buildCollections = (config: Config) => {
+  const result = mailingPlugin(config as never)({ collections: [] } as unknown as Config)
+  const collections = result.collections || []
+  return {
+    emails: collections.find((c) => c.slug === 'emails')!,
+    templates: collections.find((c) => c.slug === 'email-templates')!,
+  }
+}
+
+// Access functions receive a Payload access args object; the defaults ignore it.
+const call = (fn: unknown) => (fn as () => unknown)()
+
+describe('collection access defaults', () => {
+  it('denies every operation on both collections by default', () => {
+    const { emails, templates } = buildCollections({} as Config)
+
+    for (const collection of [emails, templates]) {
+      expect(collection.access).toBeDefined()
+      expect(call(collection.access!.read)).toBe(false)
+      expect(call(collection.access!.create)).toBe(false)
+      expect(call(collection.access!.update)).toBe(false)
+      expect(call(collection.access!.delete)).toBe(false)
+    }
+  })
+
+  it('applies an access override while leaving unspecified operations denied', () => {
+    const { emails } = buildCollections({
+      collections: {
+        emails: {
+          access: {
+            read: () => true,
+          },
+        },
+      },
+    } as unknown as Config)
+
+    // Overridden operation is granted...
+    expect(call(emails.access!.read)).toBe(true)
+    // ...while the operations the app did not override stay denied.
+    expect(call(emails.access!.create)).toBe(false)
+    expect(call(emails.access!.update)).toBe(false)
+    expect(call(emails.access!.delete)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Makes the mailing collections **prohibited (deny-all) by default** so they can't be accidentally publicized, and rewrites the README to be shorter and correct.

### Why

The `emails` and `email-templates` collections defined no `access`, so they inherited Payload's built-in default — which grants **any authenticated user** full CRUD. In an app with non-admin / front-end users, that quietly exposes email content, recipients, and templates through the REST/GraphQL API and admin panel.

## Changes

**Secure-by-default access (breaking)**
- New shared `denyAllAccess` config (`src/collections/access.ts`) applied to both collections — every operation denied by default.
- The plugin already merges `collections.*.access` overrides *on top of* the base, so granting access stays granular: any operation you don't override stays denied.
- The plugin's own sending, scheduling, and rendering are unaffected — they use Payload's Local API, which bypasses access control.
- **Action required for existing users:** grant access via `collections.emails.access` / `collections.templates.access`. Documented in the new README **Access Control** section and the changelog.
- `dev/payload.config.ts` now grants authenticated access, both to keep the dev admin/e2e working and as a live example.

**README**
- Rewritten to be concise and focused on essential usage (833 → ~340 lines), with a prominent **Access Control** section.
- Fixed stale references that no longer match the source:
  - `onReady` plugin option — does not exist.
  - `attemptCount` field in a query example — the field is `attempts`.
  - `sendTemplateEmailTask` export / `send-template-email` job task — neither exists; the plugin auto-registers its `process-email` job, so the Jobs section was corrected to reflect the real flow.

**Tests**
- Added `src/plugin.access.test.ts` locking in deny-by-default and the override-merge behavior.

## Testing

- `pnpm build:tsc` — passes
- `pnpm lint` — clean (only pre-existing warnings)
- `pnpm test` — 38 passed (5 files)

---
_Generated by [Claude Code](https://claude.ai/code/session_013GKGyRUvGj4DKpZ767xhhc)_