### PR TITLE
ci(publish): pin npm upgrade to 11.x to unblock the release publish

### DIFF
--- a/.github/workflows/version-and-publish.yml
+++ b/.github/workflows/version-and-publish.yml
@@ -84,9 +84,12 @@ jobs:
         uses: pnpm/action-setup@v4
 
       # Trusted publishing (OIDC) requires npm >= 11.5.1; Node 20 ships npm 10.x.
+      # Pin to the 11.x line: npm@latest is now 12.x, which requires Node >= 22
+      # and fails with EBADENGINE on this Node 20 runner. npm 11.x still supports
+      # OIDC trusted publishing and stays compatible with Node 20 (^20.17.0).
       - name: Update npm for trusted publishing
         if: steps.decide.outputs.publish == 'true'
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Install dependencies
         if: steps.decide.outputs.publish == 'true'


### PR DESCRIPTION
## Summary

The Publish to NPM workflow failed after #100 merged, blocking the 0.6.0 release from reaching npm. This fixes the workflow.

## Root cause

The publish job runs on Node 20 and does `npm install -g npm@latest` to get an npm new enough for OIDC trusted publishing (≥ 11.5.1). `npm@latest` has since moved to **12.x**, which declares `"node": "^22.22.2 || ^24.15.0 || >=26.0.0"` — so on the Node 20 runner it fails with:

```
npm error code EBADENGINE
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

This is a moving-target `@latest` breakage, unrelated to the dependency changes in #100.

## Fix

Pin the upgrade to the **11.x** line (`npm install -g npm@11`):

- npm 11.x still supports OIDC trusted publishing (the requirement is ≥ 11.5.1).
- npm 11.x is compatible with Node 20 (`^20.17.0 || >=22.9.0`), which the runner (v20.20.2) satisfies.
- No change to the publish runtime — bumping the runner to Node 22 would work too but is unnecessary.

## Effect

Once merged, the push to `main` re-triggers the publish workflow. It detects `package.json` (0.6.0) is ahead of npm and publishes 0.6.0 with provenance, tags `v0.6.0`, and creates the GitHub Release from the CHANGELOG section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtDhfVsobeFLosMiHxpXaY

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtDhfVsobeFLosMiHxpXaY)_